### PR TITLE
Add documentation for /api/v1/gems/latest and /api/v1/gems/just_updated

### DIFF
--- a/rubygems-org-api.md
+++ b/rubygems-org-api.md
@@ -157,6 +157,18 @@ Update a previously yanked gem back into RubyGems.org's index. Platform is optio
            https://rubygems.org/api/v1/gems/unyank
 
     Successfully unyanked gem: bills (0.0.1)
+    
+### GET - `/api/v1/gems/latest`
+
+Pulls the 50 newest first-version gems added to RubyGems.org. Returns an array of the XML or JSON representation of the gems.
+
+    $ curl 'https://rubygems.org/api/v1/gems/latest.json'
+
+### GET - `/api/v1/gems/just_updated`
+
+Pulls the 50 most recently updated gems. Returns an array of the XML or JSON representation of the gems.
+
+    $ curl 'https://rubygems.org/api/v1/gems/just_updated.json'    
 
 <a id="gemversion"> </a>
 Gem Version Methods


### PR DESCRIPTION
Corresponds to pull request #336 on the rubygems.org repo.

https://github.com/rubygems/rubygems.org/pull/336

---

Wasn't quite sure the best spot to put them within the Gems section so I stuck them at the bottom. Welcome to move them if needed.
