### PR TITLE
Include directive for IE 8 and older to use html5shiv

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <!--[if lt IE 9]>
+  <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+  <![endif]-->
   <meta charset="utf-8" />
   <title>{{ page.title }} - RubyGems Guides</title>
   <link rel="icon" href="/favicon.ico" type="image/x-icon">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!--[if lt IE 9]>
+  <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+  <![endif]-->
   <meta charset="utf-8" />
   <title>RubyGems Guides</title>
   <link rel="icon" href="/favicon.ico" type="image/x-icon">


### PR DESCRIPTION
I'm no great fan of Internet Explorer _or_ out-of-date browsers, but I'm stuck with IE 8 at work.

Since the site uses HTML 5, it looks a fright in IE 8. :-)

I've added an IE-specific directive to load [html5shiv](http://code.google.com/p/html5shiv/), and in my tests, that is all it takes to make the site readable again.

This is linked directly to the [trunk](http://code.google.com/p/html5shiv/source/browse/trunk/html5.js) version of html5shiv as per the project's recommendation, but if you want me to link it to a specific rev and/or to copy it into the static files, let me know.
