### PR TITLE
Date is not a field that is allowed in .gemspec files

### DIFF
--- a/make-your-own-gem.md
+++ b/make-your-own-gem.md
@@ -63,7 +63,6 @@ information you see on a gem page
     Gem::Specification.new do |s|
       s.name        = 'hola'
       s.version     = '0.0.0'
-      s.date        = '2010-04-28'
       s.summary     = "Hola!"
       s.description = "A simple hello world gem"
       s.authors     = ["Nick Quaranto"]


### PR DESCRIPTION
This line has been removed from the guide.
