### PR TITLE
Fix a bug in the hola example

### DIFF
--- a/make-your-own-gem.md
+++ b/make-your-own-gem.md
@@ -189,7 +189,7 @@ change much:
 
       def hi
         case @language
-        when :spanish
+        when "spanish"
           "hola mundo"
         else
           "hello world"


### PR DESCRIPTION
Fix a bug in the lib/hola/translator.rb example which try to use a symbol to match the user's input string "spanish". This has been tested and isn't gonna work in Ruby 1.8.7 and 1.9.3.
