### PR TITLE
Update instructions for setting up RubyGems.org account

### DIFF
--- a/make-your-own-gem.md
+++ b/make-your-own-gem.md
@@ -117,6 +117,11 @@ the site. To setup your computer with your RubyGems account:
     ~/.gem/credentials
     Enter host password for user 'qrush':
 
+> If you're having problems with curl, OpenSSL, or certificates, you might want to
+> simply try entering the above URL in your browser's address bar.  Your browser will
+> ask you to login to RubyGems.org.  Enter your username and password.  Your browser
+> will now try to download the file api_key.yaml.  Save it in ~/.gem and call it 'credentials'
+
 Once this has been setup, you can push out the gem:
 
     % gem push hola-0.0.0.gem


### PR DESCRIPTION
I tried using the 'curl' command but got errors about certificates.  After searching for many hours, I found out that Anaconda had installed itself in my path and I was using a different curl version.  Also, OpenSSL that is installed with Max OS X is different than the one installed with brew.  So, I finally figured out that if I just use the URL in my browser, everything works and I can avoid the hassles of curl and security certificates.  I don't know why this is happening and I don't know what certificate is used by the RubyGems.org server.  But it seems that the browser is perfectly happy with the certificate, however curl complains about the certificate.  Since this is a guide for relative beginners, I suggest to offer an alternative to curl, which is using your browser.
