### PR TITLE
Consistency for Hola & Hola::Translator classes

### DIFF
--- a/make-your-own-gem.md
+++ b/make-your-own-gem.md
@@ -150,7 +150,7 @@ this gem.
     class Hola
       def self.hi(language = "english")
         translator = Translator.new(language)
-        puts translator.hi
+        translator.hi
       end
     end
 
@@ -207,7 +207,7 @@ But now the `hola.rb` file has some code to load the `Translator`:
 
     % cat lib/hola.rb
     class Hola
-      def self.hi(language = :english)
+      def self.hi(language = "english")
         translator = Translator.new(language)
         translator.hi
       end
@@ -218,9 +218,9 @@ But now the `hola.rb` file has some code to load the `Translator`:
 Let's try this out. First, fire up `irb`:
 
     % irb -Ilib -rhola
-    irb(main):001:0> Hola.hi(:english)
+    irb(main):001:0> Hola.hi("english")
     => "hello world"
-    irb(main):002:0> Hola.hi(:spanish)
+    irb(main):002:0> Hola.hi("spanish")
     => "hola mundo"
 
 We need to use a strange command line flag here: `-Ilib`. Usually RubyGems


### PR DESCRIPTION
Two proposed small changes for the make-your-own-gem.md file:
- removing unneeded `puts` in Hola.hi method definition.
  - in the "Requiring more files" section, the class Hola `puts translator.hi` and then returns nil.  Later, in the same section, the same class definition returns translator.hi directly.  I'm suggesting removing the `puts` in the first example, as it breaks tests later in the guide.
- using string arguments consistently
  - in the "Requiring more files" section, the Hola class has a default `language` argument set to the string `"english"`.  Later in this section, the same class definition has this argument changed to `:english`, a symbol. The Hola::Translator class assumes a string `language`, and so both the example of using `Hola.hi` as well as the tests break.
