### PR TITLE
Update Github repo and user urls from HTTP -> HTTPS

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -19,20 +19,20 @@ These projects are under the wing of the core [RubyGems team](https://github.com
 Ruby's premier packaging system. Bundled with Ruby 1.9+ and available for Ruby 1.8. Any time you run
 `gem` at the command line, you're using this project.
 
-[issues](http://github.com/rubygems/rubygems/issues) -
+[issues](https://github.com/rubygems/rubygems/issues) -
 [mailing list](http://rubyforge.org/mailman/listinfo/rubygems-developers)
 
 <p class="avatars">
-  <a href="http://github.com/drbrain">
+  <a href="https://github.com/drbrain">
     <img src="https://secure.gravatar.com/avatar/58479f76374a3ba3c69b9804163f39f4?s=32" title="Eric Hodel">
   </a>
-  <a href="http://github.com/zenspider">
+  <a href="https://github.com/zenspider">
     <img src="https://secure.gravatar.com/avatar/16c4b19d8670085a428787f8b2438223?s=32" title="Ryan Davis">
   </a>
-  <a href="http://github.com/jbarnette">
+  <a href="https://github.com/jbarnette">
     <img src="https://secure.gravatar.com/avatar/c237cf537a06b60921c97804679e3b15?s=32" title="John Barnette">
   </a>
-  <a href="http://github.com/evanphx">
+  <a href="https://github.com/evanphx">
     <img src="https://secure.gravatar.com/avatar/540cb3b3712ffe045113cb03bab616a2?s=32" title="Evan Phoenix">
   </a>
 </p>
@@ -43,8 +43,8 @@ Ruby's premier packaging system. Bundled with Ruby 1.9+ and available for Ruby 1
 + Don't modify the history file or version number.
 + If you have any questions, just ask us on IRC in #rubygems or file [an issue][1].
 
-[0]: http://github.com/rubygems/rubygems
-[1]: http://github.com/rubygems/rubygems/issues
+[0]: https://github.com/rubygems/rubygems
+[1]: https://github.com/rubygems/rubygems/issues
 [2]: http://help.rubygems.org
 
 ### [RubyGems.org](https://github.com/rubygems/rubygems.org)
@@ -53,20 +53,20 @@ The Ruby community's gem hosting service. Provides a better API for accessing,
 deploying, and managing gems along with clear and accessible project pages.
 
 [site](http://rubygems.org) -
-[issues](http://github.com/rubygems/rubygems.org/issues) -
+[issues](https://github.com/rubygems/rubygems.org/issues) -
 [mailing list](https://groups.google.com/forum/#!forum/gemcutter)
 
 <p class="avatars">
-  <a href="http://github.com/qrush">
+  <a href="https://github.com/qrush">
     <img src="https://secure.gravatar.com/avatar/eb8975af8e49e19e3dd6b6b84a542e26?s=32" title="Nick Quaranto">
   </a>
-  <a href="http://github.com/sferik">
+  <a href="https://github.com/sferik">
     <img src="https://secure.gravatar.com/avatar/1f74b13f1e5c6c69cb5d7fbaabb1e2cb?s=32" title="Erik Michaels-Ober">
   </a>
-  <a href="http://github.com/cldwalker">
+  <a href="https://github.com/cldwalker">
     <img src="https://secure.gravatar.com/avatar/8f0660cdc9f5d91c7d97456f8f0be8c7?s=32" title="Gabriel Horner">
   </a>
-  <a href="http://github.com/cmeiklejohn">
+  <a href="https://github.com/cmeiklejohn">
     <img src="https://secure.gravatar.com/avatar/3e09fee7b359be847ed5fa48f524a3d3?s=32" title="Christopher Meiklejohn">
   </a>
 </p>
@@ -76,14 +76,14 @@ deploying, and managing gems along with clear and accessible project pages.
 Chef cookbooks and bootstrap scripts to configure and manage Rubygems.org on AWS.
 Includes Vagrant configuration for local testing.
 
-[issues](http://github.com/rubygems/rubygems-aws/issues)
+[issues](https://github.com/rubygems/rubygems-aws/issues)
 
 ### [RubyGems Status](https://github.com/rubygems/rubygems-status)
 
 A simple Rails app to show the status of the rubygems.org infrastructure.
 
 [site](http://status.rubygems.org) -
-[issues](http://github.com/rubygems/rubygems-status/issues)
+[issues](https://github.com/rubygems/rubygems-status/issues)
 
 ### [RubyGems Guides](https://github.com/rubygems/guides)
 
@@ -91,16 +91,16 @@ The central home for RubyGems documentation, including tutorials and reference m
 User-contributed guides are more than welcome and encouraged!
 
 [site](http://guides.rubygems.org) -
-[issues](http://github.com/rubygems/guides/issues)
+[issues](https://github.com/rubygems/guides/issues)
 
 <p class="avatars">
-  <a href="http://github.com/qrush">
+  <a href="https://github.com/qrush">
     <img src="https://secure.gravatar.com/avatar/eb8975af8e49e19e3dd6b6b84a542e26?s=32" title="Nick Quaranto">
   </a>
-  <a href="http://github.com/sandal">
+  <a href="https://github.com/sandal">
     <img src="https://secure.gravatar.com/avatar/31e038e4e9330f6c75ccfd1fca8010ee?s=32" title="Gregory Brown">
   </a>
-  <a href="http://github.com/ffmike">
+  <a href="https://github.com/ffmike">
     <img src="https://secure.gravatar.com/avatar/a54251b745d59735ea5e9f0656a5d58d?s=32" title="Mike Gunderloy">
   </a>
 </p>
@@ -114,10 +114,10 @@ on various machine architectures.
 [issues](https://github.com/rubygems/rubygems-test/issues)
 
 <p class="avatars">
-  <a href="http://github.com/bluepojo">
+  <a href="https://github.com/bluepojo">
     <img src="https://secure.gravatar.com/avatar/4b1e87301a43b027903617a98d61831a?s=32" title="Josiah Kiehl">
   </a>
-  <a href="http://github.com/erikh">
+  <a href="https://github.com/erikh">
     <img src="https://secure.gravatar.com/avatar/1b641a79b2717f2d582ad455b40d5b89?s=32" title="Erik Hollensbe">
   </a>
 </p>
@@ -133,10 +133,10 @@ pushed. Currently powers [m.rubygems.org](http://m.rubygems.org) and
 [issues](https://github.com/rubygems/gemwhisperer/issues)
 
 <p class="avatars">
-  <a href="http://github.com/qrush">
+  <a href="https://github.com/qrush">
     <img src="https://secure.gravatar.com/avatar/eb8975af8e49e19e3dd6b6b84a542e26?s=32" title="Nick Quaranto">
   </a>
-  <a href="http://github.com/laserlemon">
+  <a href="https://github.com/laserlemon">
     <img src="https://secure.gravatar.com/avatar/0887991a8846577a6aa85433d6ab3ea2?s=32" title="Steve Richert">
   </a>
 </p>
@@ -150,7 +150,7 @@ community, check this out!
 [issues](https://github.com/rubygems/gems/issues)
 
 <p class="avatars">
-  <a href="http://github.com/sferik">
+  <a href="https://github.com/sferik">
     <img src="https://secure.gravatar.com/avatar/1f74b13f1e5c6c69cb5d7fbaabb1e2cb?s=32" title="Erik Michaels-Ober">
   </a>
 </p>
@@ -163,7 +163,7 @@ A souped-up implementation of search on RubyGems.org, using Solr. Still not
 [issues](https://github.com/rubygems/search/issues)
 
 <p class="avatars">
-  <a href="http://github.com/nz">
+  <a href="https://github.com/nz">
     <img src="https://secure.gravatar.com/avatar/5198f305281b34927f936ba77cffcbf6?s=32" title="Nick Zadrozny">
   </a>
 </p>
@@ -179,7 +179,7 @@ to improve it.
 [issues](https://github.com/rubygems/rubygems-mirror/issues)
 
 <p class="avatars">
-  <a href="http://github.com/raggi">
+  <a href="https://github.com/raggi">
     <img src="https://secure.gravatar.com/avatar/b19b02a49b433c9e2e6e6c43785d2bfb?s=32" title="James Tucker">
   </a>
 </p>
@@ -189,7 +189,7 @@ to improve it.
 A collection of tools and data used for verifying the integrity of gems on rubygems.org based on checksums
 collected by third parties.
 
-[issues](http://github.com/rubygems/rubygems-verification/issues)
+[issues](https://github.com/rubygems/rubygems-verification/issues)
 
 ## Ecosystem Projects
 
@@ -205,21 +205,21 @@ many machines systematically and repeatably.
 [mailing list](https://groups.google.com/forum/#!forum/ruby-bundler)
 
 <p class="avatars">
-  <a href="http://github.com/indirect">
+  <a href="https://github.com/indirect">
     <img src="https://secure.gravatar.com/avatar/fb389f1e8b98d5d03be29e9dd309b3be?s=32" title="Andre Arko">
   </a>
-  <a href="http://github.com/hone">
+  <a href="https://github.com/hone">
     <img src="https://secure.gravatar.com/avatar/efb7c66871043330ce1310a9bdd0aaf6?s=32" title="Terence Lee">
   </a>
-  <a href="http://github.com/wycats">
+  <a href="https://github.com/wycats">
     <img src="https://secure.gravatar.com/avatar/428167a3ec72235ba971162924492609?s=32" title="Yehuda Katz">
   </a>
-  <a href="http://github.com/carllerche">
+  <a href="https://github.com/carllerche">
     <img src="https://secure.gravatar.com/avatar/da5274b27cc6c0f505495bf5d504575d?s=32" title="Carl Lerche">
   </a>
 </p>
 
-### [Isolate](http://github.com/jbarnette/isolate)
+### [Isolate](https://github.com/jbarnette/isolate)
 
 A simple gem sandbox that makes sure your application has the exact gem
 versions you require. It does not perform dependency resolution like Bundler.
@@ -227,7 +227,7 @@ versions you require. It does not perform dependency resolution like Bundler.
 [issues](https://github.com/jbarnette/isolate/issues)
 
 <p class="avatars">
-  <a href="http://github.com/jbarnette">
+  <a href="https://github.com/jbarnette">
     <img src="https://secure.gravatar.com/avatar/c237cf537a06b60921c97804679e3b15?s=32" title="John Barnette">
   </a>
 </p>
@@ -244,10 +244,10 @@ webhooks](http://guides.rubygems.org/rubygems-org-api/#webhook) as well.
 [mailing list](https://groups.google.com/forum/#!forum/yardoc)
 
 <p class="avatars">
-  <a href="http://github.com/indirect">
+  <a href="https://github.com/indirect">
     <img src="https://secure.gravatar.com/avatar/fb389f1e8b98d5d03be29e9dd309b3be?s=32" title="Andre Arko">
   </a>
-  <a href="http://github.com/hone">
+  <a href="https://github.com/hone">
     <img src="https://secure.gravatar.com/avatar/efb7c66871043330ce1310a9bdd0aaf6?s=32" title="Terence Lee">
   </a>
 </p>
@@ -261,7 +261,7 @@ internal or proprietary code to.
 [issues](https://github.com/copiousfreetime/stickler/issues)
 
 <p class="avatars">
-  <a href="http://github.com/copiousfreetime">
+  <a href="https://github.com/copiousfreetime">
     <img src="https://secure.gravatar.com/avatar/cff2d90ae70bbbb5d4865d8412159f85?s=32" title="Jeremy Hinegardner">
   </a>
 </p>
@@ -275,7 +275,7 @@ without much hassle.
 [issues](https://github.com/cwninja/geminabox/issues)
 
 <p class="avatars">
-  <a href="http://github.com/cwninja">
+  <a href="https://github.com/cwninja">
     <img src="https://secure.gravatar.com/avatar/f61c5838432c656ea88dd77a56a40f52?s=32" title="Tom Leal">
   </a>
 </p>
@@ -284,6 +284,6 @@ without much hassle.
 
 We'd love for your new idea to be on this list. If you're working on a
 RubyGems related project, just [fork this
-repo](http://github.com/rubygems/guides) and add the link!
+repo](https://github.com/rubygems/guides) and add the link!
 
 

--- a/credits.md
+++ b/credits.md
@@ -5,7 +5,7 @@ previous: /plugins
 next: /
 ---
 
-This site is [open source](http://github.com/rubygems/guides) and its content is
+This site is [open source](https://github.com/rubygems/guides) and its content is
 [Creative Commons](https://github.com/rubygems/guides/blob/gh-pages/CC-LICENSE)
 licensed.
 

--- a/gems-with-extensions.md
+++ b/gems-with-extensions.md
@@ -256,7 +256,7 @@ Further Reading
   by Aaron Patterson
 * Interfaces to C libraries can be written using ruby and
   [fiddle](http://ruby-doc.org/stdlib-2.0/libdoc/fiddle/rdoc/Fiddle.html) (part
-  of the standard library) or [ruby-ffi](http://github.com/ffi/ffi)
+  of the standard library) or [ruby-ffi](https://github.com/ffi/ffi)
 
 [README.EXT]: https://github.com/ruby/ruby/blob/trunk/README.EXT
 [mkmf.rb]: http://ruby-doc.org/stdlib-2.0/libdoc/mkmf/rdoc/MakeMakefile.html

--- a/index.md
+++ b/index.md
@@ -85,6 +85,6 @@ Extensions that use the RubyGems plugin API.
 [Credits](/credits)
 -------
 
-This site is [open source](http://github.com/rubygems/guides) and its content is
+This site is [open source](https://github.com/rubygems/guides) and its content is
 [Creative Commons](https://github.com/rubygems/guides/blob/gh-pages/CC-LICENSE)
 licensed.

--- a/make-your-own-gem.md
+++ b/make-your-own-gem.md
@@ -22,7 +22,7 @@ Introduction
 Creating and publishing your own gem is simple thanks to the tools baked right
 into RubyGems. Let’s make a simple “hello world” gem, and feel free to
 play along at home! The code for the gem we're going to make here is up
-[on GitHub](http://github.com/qrush/hola).
+[on GitHub](https://github.com/qrush/hola).
 
 <a id="first-gem"> </a>
 Your first gem

--- a/patterns.md
+++ b/patterns.md
@@ -22,7 +22,7 @@ Consistent naming
 ### File names
 
 Be consistent with how your gem files in `lib` and `bin` are named. The
-[hola](http://github.com/qrush/hola) gem from the [make your own
+[hola](https://github.com/qrush/hola) gem from the [make your own
 gem](/make-your-own-gem) guide is a great example:
 
     % tree
@@ -45,7 +45,7 @@ can easily jump in and call `require 'hola'` with no problems.
 
 Naming your gem is important.  Before you pick a name for your gem, do a
 quick search on [RubyGems.org](http://rubygems.org) and
-[GitHub](http://github.com/search) to see if someone else has taken it.  Every
+[GitHub](https://github.com/search) to see if someone else has taken it.  Every
 published gem must have a unique name.  Be sure to read our [naming
 recommendations](/name-your-gem) when you've found a name you like.
 
@@ -200,7 +200,7 @@ by using `~>` instead of `>=` if at all possible.
 
 > If you're dealing with a lot of gem dependencies in your application, we
 > recommend that you take a look into [Bundler](http://bundler.io) or
-> [Isolate](http://github.com/jbarnette/isolate) which do a great job of
+> [Isolate](https://github.com/jbarnette/isolate) which do a great job of
 > managing a complex version manifest for many gems.
 
 ### Requiring RubyGems
@@ -280,7 +280,7 @@ Or use require_relative:
 
 The [make your own gem](/make-your-own-gem) guide has a great example of this
 behavior in practice, including a working test suite. The code for that gem is
-[on GitHub](http://github.com/qrush/hola) as well.
+[on GitHub](https://github.com/qrush/hola) as well.
 
 ### Mangling the load path
 

--- a/resources.md
+++ b/resources.md
@@ -6,7 +6,7 @@ next: /contributing
 ---
 
 A collection of helpful material about RubyGems. Feel free to
-[fork](http://github.com/rubygems/guides) and add your own!
+[fork](https://github.com/rubygems/guides) and add your own!
 
 Tutorials
 ---------


### PR DESCRIPTION
The 'Hosted by Github Pages' on credits.md is unchanged and points to http://pages.github.com, as Github Pages does not use SSL.
