### PR TITLE
Fix for error message "(...)/.gem/credentials has file permissions of 06...

### DIFF
--- a/make-your-own-gem.md
+++ b/make-your-own-gem.md
@@ -115,7 +115,8 @@ gem out to RubyGems.org only takes one command, provided that you have an accoun
 the site. To setup your computer with your RubyGems account:
 
     $ curl -u qrush https://rubygems.org/api/v1/api_key.yaml >
-    ~/.gem/credentials
+    ~/.gem/credentials; chmod 0600 ~/.gem/credentials
+
     Enter host password for user 'qrush':
 
 > If you're having problems with curl, OpenSSL, or certificates, you might want to
@@ -230,7 +231,7 @@ But now the `hola.rb` file has some code to load the `Translator`:
     s.files       = ["lib/hola.rb", "lib/hola/translator.rb"]
     ...
     end
- 
+
 > without the above change, new folder would not be included into the installed gem.
 
 Let's try this out. First, fire up `irb`:


### PR DESCRIPTION
...44 but 0600 is required."

The change was suggested at https://rubygems.org/profile/edit

The complete error message:

$ gem push (gem)
ERROR:  Your gem push credentials file located at:

```
(...)/.gem/credentials
```

has file permissions of 0644 but 0600 is required.

You should reset your credentials at:

```
https://rubygems.org/profile/edit
```

if you believe they were disclosed to a third party.
