### PR TITLE
Fix broken link to security guide

### DIFF
--- a/publishing.md
+++ b/publishing.md
@@ -101,4 +101,4 @@ owner command](/command-reference/#gem_owner).
 Gem Security
 ------------
 
-See [Security](/Security) page.
+See [Security](/security) page.


### PR DESCRIPTION
At the bottom of the publishing guide is a link to the security guide.
The Link was broken because of a typo error.
