### PR TITLE
update text to match the example code

### DIFF
--- a/specification-reference.md
+++ b/specification-reference.md
@@ -265,7 +265,7 @@ discussion</p>
 <a id="add_development_dependency"> </a>
 ## add_development_dependency
 
-<p>Adds a development dependency named <code>gem</code> with
+<p>Adds a development dependency named <code>example</code> with
 <code>requirements</code> to this gem.</p>
 
 <p>Usage:</p>
@@ -278,7 +278,7 @@ activated when a gem is required.</p>
 <a id="add_runtime_dependency"> </a>
 ## add_runtime_dependency
 
-<p>Adds a runtime dependency named <code>gem</code> with
+<p>Adds a runtime dependency named <code>example</code> with
 <code>requirements</code> to this gem.</p>
 
 <p>Usage:</p>


### PR DESCRIPTION
The example code reads:

`spec.add_runtime_dependency 'example', '~> 1.1', '>= 1.1.4'`

But the explanation said "Adds a runtime dependency named `gem`."

So I changed the explanation to match the example code.
