### PR TITLE
Fix command-reference link within a page

### DIFF
--- a/command-reference.erb
+++ b/command-reference.erb
@@ -9,7 +9,7 @@ What each `gem` command does, and how to use it.
 
 This reference was automatically generated from RubyGems version <%= rubygems_version %>.
 
-<% commands.each do |name, command| %>* [gem <%= name %>](#gem-<%= name %>)
+<% commands.each do |name, command| %>* [gem <%= name %>](#gem-<%= name.gsub(/_/, '') %>)
 <% end %>
 
 <% commands.each do |name, command| %>

--- a/command-reference.md
+++ b/command-reference.md
@@ -17,7 +17,7 @@ This reference was automatically generated from RubyGems version 2.2.2.
 * [gem dependency](#gem-dependency)
 * [gem environment](#gem-environment)
 * [gem fetch](#gem-fetch)
-* [gem generate_index](#gem-generate_index)
+* [gem generate_index](#gem-generateindex)
 * [gem help](#gem-help)
 * [gem install](#gem-install)
 * [gem list](#gem-list)


### PR DESCRIPTION
The command reference link within a page does not work.

```
expect:
http://guides.rubygems.org/command-reference/#gem-build
actual:
http://guides.rubygems.org/command-reference/#gem_build
```
