### PR TITLE
Add a section on reporting security vulnerabilities

### DIFF
--- a/security.md
+++ b/security.md
@@ -138,7 +138,7 @@ If you spot a security vulnerability in someone else's gem, then you
 first step should be to check whether this is a known vulnerability.
 
 If this looks like a newly discovered vulnerability then you should
-content the author(s) privately (i.e. not via a pull request or issue on public
+contact the author(s) privately (i.e. not via a pull request or issue on public
 project) explaining the issue, how it can be exploited and ideally offering an
 indication of how it might be fixed.
 


### PR DESCRIPTION
…to the security page.

The information about requesting a CVE is taken from
https://cve.mitre.org/cve/request_id.html

It seems much less clear how to tell the world about your
issue and with no well recognised route, as far as I can tell.
In the absence of any well trodden route I have suggested the
ruby-talk mailing list since some people already use this to
announce new versions of gems.

Further discussion can be found in issue #62
