### PR TITLE
Add gem-compare to the list of RubyGems plugins

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -13,6 +13,7 @@ The following list of RubyGems plugins is probably not exhaustive. If you know o
 * [gem-ctags](#gemctags)
 * [gem_info](#geminfo)
 * [gem-init](#geminit)
+* [gem-compare](#gemcompare)
 * [gem-man](#gemman)
 * [gem-nice-install](#gemniceinstall)
 * [gem-orphan](#gemorphan)
@@ -61,6 +62,15 @@ Adds a `gem info` command with fuzzy matching on name and version. Designed for 
 [https://github.com/mwhuss/gem-init](https://github.com/mwhuss/gem-init)
 
 Adds `gem init` to create a barebones gem.
+
+<a id="gemcompare"> </a>
+## gem-compare
+
+[https://github.com/strzibny/gem-compare](https://github.com/strzibny/gem-compare)
+
+Adds `gem compare` command that can help you to track upstream changes in the released
+.gem files by comparing gemspec values, gemspec and Gemfile dependencies and files.
+
 
 <a id="gemman"> </a>
 ## gem-man


### PR DESCRIPTION
I would like to add a recently released `gem-compare` plugin to the list of known RubyGems plugins. You can find more about the plugin at https://github.com/strzibny/gem-compare.
