### PR TITLE
Update Test::Unit -> Minitest, github search link

### DIFF
--- a/make-your-own-gem.md
+++ b/make-your-own-gem.md
@@ -379,7 +379,7 @@ Now you can run `rake test` or simply just `rake` to run tests. Woot! Here's
 a basic test file for hola:
 
     % cat test/test_hola.rb
-    require 'test/unit'
+    require 'minitest/autorun'
     require 'hola'
 
     class HolaTest < Minitest::Test


### PR DESCRIPTION
Github changed its URL for searching repositories, the previous link was giving a 404 not found
