### PR TITLE
Update readme for new jekyll version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Setup
 
 Make sure you have jekyll installed (`gem install jekyll`), and run:
 
-    $ jekyll serve -w
+    $ jekyll serve
 
 The pages will be available at http://localhost:4000/
 


### PR DESCRIPTION
watch now auto-enabled by default
https://github.com/jekyll/jekyll/pull/2858
http://jekyllrb.com/news/2014/09/10/jekyll-2-4-0-released/
