### PR TITLE
Highlight contributing link in header correctly

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,6 +18,11 @@
       $(function() {
         var path = window.location.pathname;
         $('a.nav--v__link[href="'+path.substring(0, path.length -1)+'"]').addClass('is-active');
+        var header_link = $('a.header__nav-link[href="'+path.substring(0, path.length -1)+'"]');
+        if(header_link.length > 0) {
+          $('.header__nav-links a').removeClass('is-active');
+          header_link.addClass('is-active');
+        }
       });
     </script>
 


### PR DESCRIPTION
This uses the same basic logic as highlighting the current page in the sidebar to highlight the contributing link in the header when on the contributing page.
