### PR TITLE
Fix code block for the native extension guide.

### DIFF
--- a/gems-with-extensions.md
+++ b/gems-with-extensions.md
@@ -75,75 +75,75 @@ The C extension that wraps `malloc()` and `free()` goes in
     #include <ruby.h>
 
     struct my_malloc {
-  size_t size;
-  void *ptr;
+      size_t size;
+      void *ptr;
     };
 
     static void
     my_malloc_free(void *p) {
-  struct my_malloc *ptr = p;
+      struct my_malloc *ptr = p;
 
-  if (ptr->size > 0)
-      free(ptr->ptr);
+      if (ptr->size > 0)
+        free(ptr->ptr);
     }
 
     static VALUE
     my_malloc_alloc(VALUE klass) {
-  VALUE obj;
-  struct my_malloc *ptr;
+      VALUE obj;
+      struct my_malloc *ptr;
 
-  obj = Data_Make_Struct(klass, struct my_malloc, NULL, my_malloc_free, ptr);
+      obj = Data_Make_Struct(klass, struct my_malloc, NULL, my_malloc_free, ptr);
 
-  ptr->size = 0;
-  ptr->ptr  = NULL;
+      ptr->size = 0;
+      ptr->ptr  = NULL;
 
-  return obj;
+      return obj;
     }
 
     static VALUE
     my_malloc_init(VALUE self, VALUE size) {
-  struct my_malloc *ptr;
-  size_t requested = NUM2SIZET(size);
+      struct my_malloc *ptr;
+      size_t requested = NUM2SIZET(size);
 
-  if (0 == requested)
-      rb_raise(rb_eArgError, "unable to allocate 0 bytes");
+      if (0 == requested)
+        rb_raise(rb_eArgError, "unable to allocate 0 bytes");
 
-  Data_Get_Struct(self, struct my_malloc, ptr);
+      Data_Get_Struct(self, struct my_malloc, ptr);
 
-  ptr->ptr = malloc(requested);
+      ptr->ptr = malloc(requested);
 
-  if (NULL == ptr->ptr)
-      rb_raise(rb_eNoMemError, "unable to allocate %ld bytes", requested);
+      if (NULL == ptr->ptr)
+        rb_raise(rb_eNoMemError, "unable to allocate %ld bytes", requested);
 
-  ptr->size = requested;
+      ptr->size = requested;
 
-  return self;
+      return self;
     }
 
     static VALUE
     my_malloc_release(VALUE self) {
-  struct my_malloc *ptr;
+      struct my_malloc *ptr;
 
-  Data_Get_Struct(self, struct my_malloc, ptr);
+      Data_Get_Struct(self, struct my_malloc, ptr);
 
-  if (0 == ptr->size)
+      if (0 == ptr->size)
+        return self;
+
+      ptr->size = 0;
+      free(ptr->ptr);
+
       return self;
-
-  ptr->size = 0;
-  free(ptr->ptr);
-
-  return self;
     }
 
     void
     Init_my_malloc(void) {
-  VALUE cMyMalloc;
+      VALUE cMyMalloc;
 
-  cMyMalloc = rb_const_get(rb_cObject, rb_intern("MyMalloc"));
+      cMyMalloc = rb_const_get(rb_cObject, rb_intern("MyMalloc"));
 
-  rb_define_alloc_func(cMyMalloc, my_malloc_alloc);
-  rb_define_method(cMyMalloc, "initialize", my_malloc_init, 1);
-  rb_define_method(cMyMalloc, "free", my_malloc_release, 0);
+      rb_define_alloc_func(cMyMalloc, my_malloc_alloc);
+      rb_define_method(cMyMalloc, "initialize", my_malloc_init, 1);
+      rb_define_method(cMyMalloc, "free", my_malloc_release, 0);
     }
 
 This extension is simple with just a few parts:
@@ -264,4 +264,3 @@ Further Reading
 [README.EXT]: https://github.com/ruby/ruby/blob/trunk/README.EXT
 [mkmf.rb]: http://ruby-doc.org/stdlib-2.0/libdoc/mkmf/rdoc/MakeMakefile.html
 [rake-compiler]: https://github.com/luislavena/rake-compiler
-


### PR DESCRIPTION
Fix the broken code block on the guide for [gems with extensions](http://guides.rubygems.org/gems-with-extensions/).