### PR TITLE
add namespace in hola/translator example

### DIFF
--- a/make-your-own-gem.md
+++ b/make-your-own-gem.md
@@ -194,7 +194,7 @@ The `Translator` is now in `lib/hola`, which can easily be picked up with a
 change much:
 
     % cat lib/hola/translator.rb
-    class Translator
+    class Hola::Translator
       def initialize(language)
         @language = language
       end


### PR DESCRIPTION
It's better to add namespace in gem's internal class, and same as the previous example.