### PR TITLE
Correct the anchor name for the gem-owner command

### DIFF
--- a/publishing.md
+++ b/publishing.md
@@ -99,7 +99,7 @@ Push Permissions on RubyGems.org
 
 If you have multiple maintainers for your gem you can give your fellow
 maintainers permission to push the gem to rubygems.org through the [gem
-owner command](/command-reference/#gem_owner).
+owner command](/command-reference/#gem-owner).
 
 Gem Security
 ------------


### PR DESCRIPTION
The link to the documentation for the `gem owner` command uses a hash fragment to take you to the right part of the page - lovely. Unfortunately the fragment isn't correct so you're left sat at the top of the page after navigation - oh dear.

This pull request fixes that.