### PR TITLE
fixes to gems-with-c-extensions guide

### DIFF
--- a/gems-with-extensions.md
+++ b/gems-with-extensions.md
@@ -139,7 +139,7 @@ The C extension that wraps `malloc()` and `free()` goes in
     Init_my_malloc(void) {
       VALUE cMyMalloc;
 
-      cMyMalloc = rb_const_get(rb_cObject, rb_intern("MyMalloc"));
+      cMyMalloc = rb_define_class("MyMalloc", rb_cObject)
 
       rb_define_alloc_func(cMyMalloc, my_malloc_alloc);
       rb_define_method(cMyMalloc, "initialize", my_malloc_init, 1);
@@ -166,7 +166,7 @@ You can test building the extension as follows:
     compiling my_malloc.c
     linking shared-object my_malloc.bundle
     $ cd ../..
-    $ ruby -Ilib:ext -r my_malloc -e "p MyMalloc.new(5).free"
+    $ ruby -Iext/my_malloc -r my_malloc -e "p MyMalloc.new(5).free"
     #<MyMalloc:0x007fed838addb0>
 
 But this will get tedious after a while.  Let's automate it!


### PR DESCRIPTION
This attempts to fix two issues that I ran into when following this guide:

1) the ruby `-I` argument seems to want a relative path the the extension.
2) `rb_const_get` did not seem to be properly create the object, so I changed that to `rb_define_class`.

Changing these two issues allowed me to build the example, but there may have been other issues as to why I wasn't able to build the example as is.  I am running MRI 2.1.6 through rbenv.
