### PR TITLE
Add a page for rubygems.org/api/v2

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -87,6 +87,7 @@
               <a class="nav--v__link" href="/command-reference">Command Reference</a>
               <a class="nav--v__link" href="http://docs.seattlerb.org/rubygems">RubyGems API</a>
               <a class="nav--v__link" href="/rubygems-org-api">RubyGems.org API</a>
+              <a class="nav--v__link" href="/rubygems-org-api-v2">RubyGems.org API V2.0</a>
               <a class="nav--v__link" href="/run-your-own-gem-server">Run your own gem server</a>
               <a class="nav--v__link" href="/resources">Resources</a>
               <a class="nav--v__link" href="/contributing">Contributing to RubyGems</a>

--- a/rubygems-org-api-v2.md
+++ b/rubygems-org-api-v2.md
@@ -1,0 +1,35 @@
+---
+layout: default
+title: RubyGems.org API V2
+url: /rubygems-org-api-v2
+previous: /rubygems-org-api
+next: /run-your-own-gem-server
+---
+
+> NOTE: This API version is under construction! It might change without further notice.
+
+Gem Version Methods
+-------------------
+
+### GET - `/api/v2/rubygems/[GEM NAME]/versions/[VERSION NUMBER].(json|yaml)`
+
+Returns a dictionary with versions details for a specific gem version. Example:
+
+    $ curl https://rubygems.org/api/v2/rubygems/coulda/versions/0.7.1.json
+
+    {
+      "authors":"Evan David Light",
+      "built_at":"2011-08-08T04:00:00.000Z",
+      "created_at":"2011-08-08T21:23:40.254Z",
+      "description":"Behaviour Driven Development derived from Cucumber but as an internal DSL with methods for reuse",
+      "downloads_count":2469,
+      "metadata":{},
+      "number":"0.7.1",
+      "summary":"Test::Unit-based acceptance testing DSL",
+      "platform":"ruby",
+      "ruby_version":null,
+      "prerelease":false,
+      "licenses":null,
+      "requirements":null,
+      "sha":"777c3a7ed83e44198b0a624976ec99822eb6f4a44bf1513eafbc7c13997cd86c"
+    }

--- a/rubygems-org-api.md
+++ b/rubygems-org-api.md
@@ -3,7 +3,7 @@ layout: default
 title: RubyGems.org API
 url: /rubygems-org-api
 previous: /command-reference
-next: /run-your-own-gem-server
+next: /rubygems-org-api-v2
 ---
 
 <em class="t-gray">Details on interacting with RubyGems.org over HTTP.</em>

--- a/run-your-own-gem-server.md
+++ b/run-your-own-gem-server.md
@@ -2,7 +2,7 @@
 layout: default
 title: Run your own gem server
 url: /run-your-own-gem-server
-previous: /rubygems-org-api
+previous: /rubygems-org-api-v2
 next: /resources
 ---
 


### PR DESCRIPTION
The first endpoint was include in rubygems/rubygems.org#980
