### PR TITLE
Fixed pluarlity typo of 'inside a gems are' to 'inside gems are'

### DIFF
--- a/what-is-a-gem.md
+++ b/what-is-a-gem.md
@@ -22,7 +22,7 @@ sometimes the operating system version.  Examples include "x86-mingw32" or
 same platform.  RubyGems will automatically download the correct version for
 your platform.  See `gem help platform` for full details.
 
-Inside a gems are the following components:
+Inside gems are the following components:
 
 * Code (including tests and supporting utilities)
 * Documentation


### PR DESCRIPTION
There was a small typo inside the 'what-is-a-gem' file that stated: "Inside a gems are the following components". Fixed to "Inside gems are the ..."