### PR TITLE
Fix comment for ~> operator

### DIFF
--- a/specification-reference.md
+++ b/specification-reference.md
@@ -519,7 +519,7 @@ ruby 2.0.0p247 (2013-06-27 revision 41674) [x86_64-darwin12.4.0]
 <pre class="ruby"><span class="ruby-comment"># This gem will work with 1.8.6 or greater...</span>
 <span class="ruby-identifier">spec</span>.<span class="ruby-identifier">required_ruby_version</span> = <span class="ruby-string">&#39;&gt;= 1.8.6&#39;</span>
 
-<span class="ruby-comment"># Only with ruby 2.0.x</span>
+<span class="ruby-comment"># Only with ruby 2.x</span>
 <span class="ruby-identifier">spec</span>.<span class="ruby-identifier">required_ruby_version</span> = <span class="ruby-string">&#39;~&gt; 2.0&#39;</span>
 
 <span class="ruby-comment"># Only with ruby between 2.2.0 and 2.2.2</span>


### PR DESCRIPTION
As described in the [patterns guide](https://github.com/rubygems/guides/blob/gh-pages/patterns.md), the ~> operator behaves differently
depending on how many levels of the version you specify:

* `~> 2.0` is equivalent to `'>= 2.0', '< 3.0'` (or colloquial `2.x`)
* `~> 2.0.0` is equivalent to `'>= 2.0.0', '< 2.1.0'` (or colloquial `2.0.x`)