### PR TITLE
Fix broken link

### DIFF
--- a/specification-reference.md
+++ b/specification-reference.md
@@ -9,7 +9,7 @@ next: /command-reference
 
 
 <p>The Specification class contains the
-information for a <a href="../Gem.html">Gem</a>.  Typically defined in a
+information for a <a href="../what-is-a-gem/">Gem</a>.  Typically defined in a
 .gemspec file or a Rakefile, and looks like this:</p>
 
 <pre class="ruby"><span class="ruby-constant">Gem</span><span class="ruby-operator">::</span><span class="ruby-constant">Specification</span>.<span class="ruby-identifier">new</span> <span class="ruby-keyword">do</span> <span class="ruby-operator">|</span><span class="ruby-identifier">s</span><span class="ruby-operator">|</span>


### PR DESCRIPTION
You can find this link on [guides.rubygems.org/specification-reference/](http://guides.rubygems.org/specification-reference/) in the first paragraph.