### PR TITLE
Add Gemfile for deploying review apps to heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'jekyll'
+gem 'rack-jekyll'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,57 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    colorator (1.1.0)
+    ffi (1.9.18)
+    forwardable-extended (2.6.0)
+    jekyll (3.5.2)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-sass-converter (1.5.0)
+      sass (~> 3.4)
+    jekyll-watch (1.5.0)
+      listen (~> 3.0, < 3.1)
+    kramdown (1.15.0)
+    liquid (4.0.0)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    pathutil (0.14.0)
+      forwardable-extended (~> 2.6)
+    public_suffix (3.0.0)
+    rack (1.6.8)
+    rack-jekyll (0.5.0)
+      jekyll (>= 1.3)
+      listen (>= 1.3)
+      rack (~> 1.5)
+    rb-fsevent (0.10.2)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    rouge (1.11.1)
+    safe_yaml (1.0.4)
+    sass (3.5.1)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll
+  rack-jekyll
+
+BUNDLED WITH
+   1.15.4

--- a/README.md
+++ b/README.md
@@ -25,9 +25,13 @@ are gladly accepted!
 Setup
 =====
 
-Make sure you have jekyll installed (`gem install jekyll`), and run:
+Install the required dependencies using [Bundler](https://github.com/bundler/bundler)
 
-    $ jekyll serve
+    $ bundle install
+
+To start the application run:
+
+    $ bundle exec jekyll serve
 
 The pages will be available at http://localhost:4000/
 

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,3 @@
+require "rack/jekyll"
+
+run Rack::Jekyll.new


### PR DESCRIPTION
This PR creates a Gemfile and relevant files that will allow us to deploy our rubygems guides to Heroku.

This will let maintainers create review apps for PRs from contributors and more easily provide feedback.

I've also amended the documentation to run `bundle install` and run Jekyll with `bundle exec`