### PR TITLE
Update intro text in plugins page

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -9,11 +9,9 @@ next: /credits
 <em class="t-gray">Extensions that use the RubyGems plugin API.</em>
 
 As of RubyGems 1.3.2, RubyGems will load plugins installed in gems or
-$LOAD\_PATH.  Plugins must be named 'rubygems\_plugin' (.rb, .so, etc)
+`$LOAD_PATH`.  Plugins must be named 'rubygems\_plugin' (.rb, .so, etc)
 and placed at the root of your gem's #require\_path.  Plugins are
-discovered via Gem::find\_files then loaded.  Take care when
-implementing a plugin as your plugin file may be loaded multiple times
-if multiple versions of your gem are installed.
+discovered via `Gem::find_files` then loaded.
 
 The following list of RubyGems plugins is probably not exhaustive. If you know of plugins that we missed, feel free to update this page.
 

--- a/plugins.md
+++ b/plugins.md
@@ -8,7 +8,12 @@ next: /credits
 
 <em class="t-gray">Extensions that use the RubyGems plugin API.</em>
 
-As of RubyGems 1.3.2, RubyGems will load plugins installed in gems or $LOAD\_PATH.  Plugins must be named 'rubygems\_plugin' (.rb, .so, etc) and placed at the root of your gem's #require\_path.  Plugins are discovered via Gem::find\_files then loaded.  Take care when implementing a plugin as your plugin file may be loaded multiple times if multiple versions of your gem are installed.
+As of RubyGems 1.3.2, RubyGems will load plugins installed in gems or
+$LOAD\_PATH.  Plugins must be named 'rubygems\_plugin' (.rb, .so, etc)
+and placed at the root of your gem's #require\_path.  Plugins are
+discovered via Gem::find\_files then loaded.  Take care when
+implementing a plugin as your plugin file may be loaded multiple times
+if multiple versions of your gem are installed.
 
 The following list of RubyGems plugins is probably not exhaustive. If you know of plugins that we missed, feel free to update this page.
 


### PR DESCRIPTION
* Remove warning about a plugin being loaded multiple times: since
  RubyGems 2.1.0, a RubyGems plugin is now only loaded from the latest
  installed gem;
* Mark ruby code as "code span".

---

Also see: https://github.com/rubygems/rubygems/pull/2103
