### PR TITLE
[WIP] Remove inactive projects from /contributing

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -130,25 +130,6 @@ User-contributed guides are more than welcome and encouraged!
   </a>
 </p>
 
-<a class="project__name" href="https://github.com/rubygems/rubygems-test">RubyGems Testers</a>
-
-A community effort to document the test results for various gems,
-on various machine architectures.
-
-<div class="project__links">
-  <a class="project__link t-link" href="http://test.rubygems.org/">Site</a>
-  <a class="project__link t-link" href="https://github.com/rubygems/rubygems-test/issues">Issues</a>
-</div>
-
-<p class="avatars">
-  <a href="https://github.com/bluepojo">
-    <img src="https://secure.gravatar.com/avatar/4b1e87301a43b027903617a98d61831a?s=32" title="Josiah Kiehl">
-  </a>
-  <a href="https://github.com/erikh">
-    <img src="https://secure.gravatar.com/avatar/1b641a79b2717f2d582ad455b40d5b89?s=32" title="Erik Hollensbe">
-  </a>
-</p>
-
 <a class="project__name" href="https://github.com/rubygems/gemwhisperer">Gem Whisperer</a>
 
 An example of how to use [RubyGems.org's

--- a/contributing.md
+++ b/contributing.md
@@ -108,27 +108,6 @@ Chef cookbooks and bootstrap scripts to configure and manage Rubygems.org on AWS
   </a>
 </p>
 
-<a class="project__name" href="https://github.com/rubygems/rubygems-status">RubyGems Status</a>
-
-A simple Rails app to show the status of the rubygems.org infrastructure.
-
-<div class="project__links">
-  <a class="project__link t-link" href="http://status.rubygems.org">Site</a>
-  <a class="project__link t-link" href="https://github.com/rubygems/rubygems-status/issues">Issues</a>
-</div>
-
-<p class="avatars">
-  <a href="https://github.com/sferik">
-    <img src="https://secure.gravatar.com/avatar/1f74b13f1e5c6c69cb5d7fbaabb1e2cb?s=32" title="Erik Michaels-Ober">
-  </a>
-  <a href="https://github.com/dwradcliffe">
-    <img src="https://secure.gravatar.com/avatar/013fd4dfb0e29744d5f37cf9068ba930?s=32" title="David Radcliffe">
-  </a>
-  <a href="https://github.com/arthurnn">
-    <img src="https://secure.gravatar.com/avatar/bd33b5aaf0eb48d67a8145732d8f61a9?s=32" title="Arthur Nogueira Neves">
-  </a>
-</p>
-
 <a class="project__name" href="https://github.com/rubygems/guides">RubyGems Guides</a>
 
 The central home for RubyGems documentation, including tutorials and reference material.

--- a/contributing.md
+++ b/contributing.md
@@ -227,21 +227,6 @@ many machines systematically and repeatably.
   </a>
 </p>
 
-<a class="project__name" href="https://github.com/jbarnette/isolate">Isolate</a>
-
-A simple gem sandbox that makes sure your application has the exact gem
-versions you require. It does not perform dependency resolution like Bundler.
-
-<div class="project__links">
-  <a class="project__link t-link" href="https://github.com/jbarnette/isolate/issues">Issues</a>
-</div>
-
-<p class="avatars">
-  <a href="https://github.com/jbarnette">
-    <img src="https://secure.gravatar.com/avatar/c237cf537a06b60921c97804679e3b15?s=32" title="John Barnette">
-  </a>
-</p>
-
 <a class="project__name" href="https://github.com/lsegal/rubydoc.info">RubyDoc.info</a>
 
 A fantastic provider of [YARD](http://yardoc.org) documentation for every


### PR DESCRIPTION
If we're going to be pointing people at projects, we ought to be pointing them at projects that are actively maintained.

Given that, I updated the /contributing page in the following ways:

1. Removed rubygems-status link, because it's deprecated.
2. Removed rubygems-test link, because it's been untouched for >6 years.
3. Removed isolate link, because it's been untouched for >2.5 years.

I'm unsure if the following need to be updated:

1. is [gemwhisperer](https://github.com/rubygems/gemwhisperer) still a thing? (cc @qrush)
2. should the link to [tomlea/geminabox](https://github.com/tomlea/geminabox) be changed to [geminabox/geminabox](https://github.com/geminabox/geminabox)?
    * tomlea/geminabox is 96 commits behind geminabox/geminabox..
3. is [stickler](https://github.com/copiousfreetime/stickler) still a thing? (cc @copiousfreetime)

Other questions:

1. is there anything else I've not mentioned that should be updated?
2. for anything that is no longer active, is there an updated variant or an actively-maintained alternative?