### PR TITLE
fix permalink: /specification-refence → /specification-reference

### DIFF
--- a/rdoc/generator/template/jekdoc/classpage.rhtml
+++ b/rdoc/generator/template/jekdoc/classpage.rhtml
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Specification Reference
-url: /specification-refence
+url: /specification-reference
 previous: /patterns
 next: /command-reference
 ---

--- a/specification-reference.md
+++ b/specification-reference.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Specification Reference
-url: /specification-refence
+url: /specification-reference
 previous: /patterns
 next: /command-reference
 ---


### PR DESCRIPTION
currently the typo link works and the correct link 404s e.g.:

  - http://guides.rubygems.org/specification-reference 404
  - http://guides.rubygems.org/specification-refence OK

see #205