### PR TITLE
Fix FAQ command to print Gem.user_dir

### DIFF
--- a/faqs.md
+++ b/faqs.md
@@ -40,7 +40,7 @@ For example, if you use bash you can add that directory to your `PATH` by
 adding code like this to your `~/.bashrc` file:
 
     if which ruby >/dev/null && which gem >/dev/null; then
-        PATH="$(ruby -rubygems -e 'puts Gem.user_dir')/bin:$PATH"
+        PATH="$(ruby -r rubygems -e 'puts Gem.user_dir')/bin:$PATH"
     fi
 
 After adding this code to your `~/.bashrc`, you need to restart your shell for


### PR DESCRIPTION
The FAQ currently includes the command `ruby -rubygems -e 'puts Gem.user_dir'` in the "I installed gems with --user-install and their commands are not available" section.  When I run this command it prints the following error:

    /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require': cannot load such file -- ubygems (LoadError)
        from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'

Which makes sense given that `ubygems` was passed to the `-r` option and no such module exists on my system.

This PR changes the command to pass `-r rubygems` which appears to be the intent and correctly prints the gem user directory on my system.

Note that `-r rubygems` is not required on my system.  I'm not knowledgeable enough about RubyGems to know whether it might be required on some systems.  If not, I can update this PR to remove it.

Thanks for considering,
Kevin