### PR TITLE
Fix non-existant url for `History of RDoc presentation`

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -28,7 +28,7 @@ Tutorials
 Presentations
 -------------
 
-* [History of RDoc and RubyGems](http://confreaks.tv/videos/rubyconf2010-history-of-rdoc-and-rubygems)
+* [History of RDoc and RubyGems](https://web.archive.org/web/20110527141407/http://blog.segment7.net/2011/01/17/history-of-rdoc-and-rubygems)
 * [Building a Gem](http://www.slideshare.net/sarah.allen/building-a-ruby-gem)
 * [Gemology](http://www.slideshare.net/copiousfreetime/gemology)
 

--- a/resources.md
+++ b/resources.md
@@ -28,7 +28,7 @@ Tutorials
 Presentations
 -------------
 
-* [History of RDoc and RubyGems](http://blog.segment7.net/2011/01/17/history-of-rdoc-and-rubygems)
+* [History of RDoc and RubyGems](http://confreaks.tv/videos/rubyconf2010-history-of-rdoc-and-rubygems)
 * [Building a Gem](http://www.slideshare.net/sarah.allen/building-a-ruby-gem)
 * [Gemology](http://www.slideshare.net/copiousfreetime/gemology)
 


### PR DESCRIPTION
* [Web Archive URL](https://web.archive.org/web/20110527141407/http://blog.segment7.net/2011/01/17/history-of-rdoc-and-rubygems)
* [Presentation Video](http://confreaks.tv/videos/rubyconf2010-history-of-rdoc-and-rubygems)
* [Slides](https://web.archive.org/web/20110527141407/http://segment7.net/projects/ruby/RubyConf/2010/History%20of%20RubyGems%20and%20RDoc%20-%20RubyConf%202010.pdf)