### PR TITLE
command-reference.md - fix md parsing in 'Options'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -126,7 +126,7 @@ file 'command-reference.md' =>
           if helpline =~ /options/i
             options += "\n### #{helpline}\n"
           else
-            options += "* #{helpline}\n"
+            options += "* #{helpline.strip}\n"
           end
         end
       end


### PR DESCRIPTION
See Issue https://github.com/rubygems/guides/issues/233