### PR TITLE
Update outdated Bundler links and also use https

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -221,7 +221,7 @@ Bundler manages an application's dependencies through its entire life across
 many machines systematically and repeatably.
 
 <div class="project__links">
-  <a class="project__link t-link" href="http://bundler.io">Site</a>
+  <a class="project__link t-link" href="https://bundler.io/">Site</a>
   <a class="project__link t-link" href="https://github.com/bundler/bundler/issues">Issues</a>
   <a class="project__link t-link" href="https://groups.google.com/forum/#!forum/ruby-bundler">Mailing List</a>
 </div>

--- a/make-your-own-gem.md
+++ b/make-your-own-gem.md
@@ -9,7 +9,7 @@ next: /gems-with-extensions
 <p><em class="t-gray">From start to finish, learn how to package your Ruby code in a gem.</em></p>
 <p><em class="t-gray">Note: Many people use Bundler to create Gems. You can
 learn how to do that by reading the &ldquo;<a
-href="https://bundler.io/v1.13/guides/creating_gem">Developing a RubyGem
+href="https://bundler.io/v2.0/guides/creating_gem.html">Developing a RubyGem
 using Bundler</a>&rdquo; guide on the Bundler website.</em></p>
 
 * [Introduction](#introduction)

--- a/patterns.md
+++ b/patterns.md
@@ -128,7 +128,7 @@ specific version of a gem:
     require "extlib"
 
 It's reasonable for applications that consume gems to use this (though they
-could also use a tool like [Bundler](http://bundler.io)). Gems themselves
+could also use a tool like [Bundler](https://bundler.io/)). Gems themselves
 **should not** do this. They should instead use dependencies in the gemspec so
 RubyGems can handle loading the dependency instead of the user.
 
@@ -200,7 +200,7 @@ your gems, so guard yourself from potential bugs/failures in future releases
 by using `~>` instead of `>=` if at all possible.
 
 > If you're dealing with a lot of gem dependencies in your application, we
-> recommend that you take a look into [Bundler](http://bundler.io) or
+> recommend that you take a look into [Bundler](https://bundler.io/) or
 > [Isolate](https://github.com/jbarnette/isolate) which do a great job of
 > managing a complex version manifest for many gems.
 

--- a/publishing.md
+++ b/publishing.md
@@ -33,7 +33,7 @@ The simplest way (from the author's perspective) to share a gem for other
 developers' use is to distribute it in source code form. If you place the full
 source code for your gem on a public git repository (often, though not always,
 this means sharing it via [GitHub](https://github.com)), then other users can
-install it with [Bundler's git functionality](http://bundler.io/git.html).
+install it with [Bundler's git functionality](https://bundler.io/v2.0/man/gemfile.5.html#GIT).
 
 For example, you can install the latest code for the wicked_pdf gem in a
 project by including this line in your Gemfile:

--- a/run-your-own-gem-server.md
+++ b/run-your-own-gem-server.md
@@ -58,7 +58,7 @@ Include the following in a `config.ru` file:
     [~/dev/geminabox] cat config.ru
     require "rubygems"
     require "geminabox"
-    
+
     Geminabox.data = "./data"
     run Geminabox::Server
 
@@ -88,12 +88,12 @@ read the [Gem in a box](https://github.com/geminabox/geminabox) README.
 
 ## Running Gemirro
 
-If you need a simple application that makes it easy way to create your own 
-RubyGems mirror without having to push or write all gem you wanted in a 
-configuration file try out [Gemirro](https://github.com/PierreRambaud/gemirro). 
-It does mirroring without any authentication and you can add your private 
-gems in the gems directory. More, to mirroring a source, you only need 
-to start the server, and gems will automaticly be downloaded when needed. 
+If you need a simple application that makes it easy way to create your own
+RubyGems mirror without having to push or write all gem you wanted in a
+configuration file try out [Gemirro](https://github.com/PierreRambaud/gemirro).
+It does mirroring without any authentication and you can add your private
+gems in the gems directory. More, to mirroring a source, you only need
+to start the server, and gems will automaticly be downloaded when needed.
 
 To get started, install `gemirro`:
 
@@ -147,13 +147,13 @@ Then install gems as usual:
     Successfully installed secretgem-0.0.1
     1 gem installed
 
-If you're using [Bundler](http://bundler.io) then you can specify this
+If you're using [Bundler](https://bundler.io/) then you can specify this
 server as a gem source in your `Gemfile`:
 
     [~/dev/myapp] cat Gemfile
     source "http://localhost:9292"
     gem "secretgem"
-    
+
     [~/dev/myapp] bundle
     Using secretgem (0.0.1)
     Using bundler (1.0.13)

--- a/ssl-certificate-update.md
+++ b/ssl-certificate-update.md
@@ -8,13 +8,13 @@ next: /patterns
 
 # SSL Certificate Updates
 
-If you’ve seen the following SSL error when trying to pull updates from RubyGems: 
+If you’ve seen the following SSL error when trying to pull updates from RubyGems:
 
 ```OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed```
 
 This error happens when your computer is missing a file that it needs to verify that the server behind RubyGems.org is the correct one.
 
-Follow the steps outlined in [the RubyGems and Bundler OpenSSL/TLS guide](http://bundler.io/v1.16/guides/rubygems_tls_ssl_troubleshooting_guide.html#troubleshooting-certificate-errors) to troubleshoot the problem.
+Follow the steps outlined in [the RubyGems and Bundler OpenSSL/TLS guide](https://bundler.io/v2.0/guides/rubygems_tls_ssl_troubleshooting_guide.html#troubleshooting-certificate-errors) to troubleshoot the problem.
 
-If you're still encountering issues, you can open an 
+If you're still encountering issues, you can open an
 [issue on GitHub](https://github.com/rubygems/rubygems).


### PR DESCRIPTION
A couple of Bundler links were outdated (either using an older version or broken) and have been updated. Also links with `http` have been updated to use `https`.