### PR TITLE
Create git-secretssion SoftU2F-awslabse

### DIFF
--- a/git-secretssion SoftU2F-awslabse
+++ b/git-secretssion SoftU2F-awslabse
@@ -1,0 +1,3 @@
+HEAD is now at 797336a Merge a974c84b58fe482851b852867dcf6efa0b9d508b into 2e92951fefb58b94d3b324b51f665906e0e448f7
+Fri, 22 Nov 2019 13:13:08 GMT Removed matchers: 'checkout-git'
+


### PR DESCRIPTION
HEAD is now at 797336a Merge a974c84b58fe482851b852867dcf6efa0b9d508b into 2e92951fefb58b94d3b324b51f665906e0e448f7
Fri, 22 Nov 2019 13:13:08 GMT Removed matchers: 'checkout-git'
https://github.com/ruzyysmartt/explore/commit/a974c84b58fe482851b852867dcf6efa0b9d508bhttps://github.com/github/explore/issues/1234#issue-524011781