### PR TITLE
Fix URI of Common Vulnerabilities and Exposures

### DIFF
--- a/cve.md
+++ b/cve.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: RubyGems Common Vulnerabilities and Exposures
-permalink: /cve
+url: /cve
 ---
 
 # RubyGems Common Vulnerabilities and Exposures


### PR DESCRIPTION
This PR makes cve.md consistent with other pages by setting `page.url` variable instead of `permalink`. It fixes a couple of bugs:
- Makes `/cve/` a valid path. All other pages can be accessed both with and without a trailing slash, now this page too.
- On `/cve`, marks the **Common Vulnerabilities and Exposures** sidebar link as active, as it should be.