### PR TITLE
Add removing a published gem guide

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -62,6 +62,7 @@
           <nav class="header__nav-links">
             <a class="header__nav-link" href="https://rubygems.org/gems">Gems</a>
             <a class="header__nav-link is-active" href="/">Guides</a>
+            <a class="header__nav-link" href="https://blog.rubygems.org">Blog</a>
             <a class="header__nav-link" href="/contributing">Contribute</a>
           </nav>
         </div>
@@ -81,6 +82,7 @@
               <a class="nav--v__link" href="/name-your-gem">Name your gem</a>
               <a class="nav--v__link" href="/publishing">Publishing your gem</a>
               <a class="nav--v__link" href="/security">Security Practices</a>
+              <a class="nav--v__link" href="/removing-a-published-gem">Removing a Published gem</a>
               <a class="nav--v__link" href="/ssl-certificate-update">SSL Certificate Update</a>
               <a class="nav--v__link" href="/patterns">Patterns</a>
               <a class="nav--v__link" href="/specification-reference">Specification Reference</a>

--- a/removing-a-published-gem.md
+++ b/removing-a-published-gem.md
@@ -1,0 +1,21 @@
+---
+layout: default
+title: Removing a published gem
+url: /removing-a-published-gem
+previous: /security
+next: /ssl-certificate-update
+---
+
+<em class="t-gray">Published a gem before it was ready for release? Published a gem with the wrong name?</em>
+
+Here's how you can fix it.
+
+You can use the gem yank command to remove versions from RubyGems.org's index using the command:
+
+```ruby
+gem yank GEM -v VERSION
+```
+
+Running gem yank will remove your gem from being available with gem install and the other gem commands. This also removes the gem file, as of April 20, 2015.
+
+Note: Our webhook and mirror system means that several hundred services get pinged when new gems are pushed, so it's prudent to immediately reset any passwords/sensitive data you accidentally pushed even if you yank a gem right away.

--- a/security.md
+++ b/security.md
@@ -3,7 +3,7 @@ layout: default
 title: Security
 url: /security
 previous: /publishing
-next: /ssl-certificate-update
+next: /removing-a-published-gem
 ---
 
 <em class="t-gray">How to build and install cryptographically signed gems-- and other security concerns.</em>


### PR DESCRIPTION
 - [Removing a published gem](https://help.rubygems.org/kb/gemcutter/removing-a-published-rubygem) found in help.rubygems.org is a very helpful guide we should consider adding it to the docs.
- added blog to navbar for visibility