### PR TITLE
Update plugin overview to reflect new plugin system

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -11,10 +11,10 @@ Plugins
 
 <em class="t-gray">Extensions that use the RubyGems plugin API.</em>
 
-As of RubyGems 1.3.2, RubyGems will load plugins installed in gems or
-`$LOAD_PATH`.  Plugins must be named 'rubygems\_plugin' (.rb, .so, etc)
-and placed at the root of your gem's #require\_path.  Plugins are
-discovered via `Gem::find_files` then loaded.
+RubyGems will load plugins in the latest version of each installed gem or
+`$LOAD_PATH`.  Plugins must be named 'rubygems\_plugin' (.rb, .so, etc) and
+placed at the root of your gem's #require\_path.  Plugins are installed at a
+special location and loaded on boot.
 
 
 Make your own plugin


### PR DESCRIPTION
Resolves #268

This updates the overview of how RubyGems plugins work to reflect the new plugin system.

The plug in system was reworked to make it faster by caching plugins from gems into a central location instead of having to find and load them from each time.

In [a discussion on an plugin related issue](https://github.com/rubygems/rubygems/issues/3239#issuecomment-692006599
), it was discovered that the current overview in the documentation does not reflect how things work after the updates to the plugin system.

This updates the language used in the overview to match a similar change of language in that PR here: https://github.com/rubygems/rubygems/blob/a28724fdd9262d716e6facb1950387a0a6ac4c73/lib/rubygems.rb#L45-L48
