### PR TITLE
Add deprecation note for `gem query`

### DIFF
--- a/command-reference.md
+++ b/command-reference.md
@@ -1225,6 +1225,8 @@ authenticate.
 
 Query gem information in local or remote repositories
 
+* *NOTE:* `query` is deprecated as of RubyGems 3.2
+
 ### Usage
 
     gem query [options]


### PR DESCRIPTION
It was noted in rubygems/rubygems#3984 that the documentation for `gem query` had not been updated to reflect its deprecated status. This change is meant to address that.

**Note:** This is the second of two pull requests meant to address rubygems/rubygems#3984. When both have been merged, the issue should be closed.