### PR TITLE
Remove date from spec example

### DIFF
--- a/make-your-own-gem.md
+++ b/make-your-own-gem.md
@@ -66,7 +66,6 @@ information you see on a gem page
     Gem::Specification.new do |s|
       s.name        = 'hola'
       s.version     = '0.0.0'
-      s.date        = '2010-04-28'
       s.summary     = "Hola!"
       s.description = "A simple hello world gem"
       s.authors     = ["Nick Quaranto"]


### PR DESCRIPTION
Eliminate any confusion since it's been deprecated for some time.

See:
https://github.com/rubygems/rubygems/issues/1232#issuecomment-97253757