### PR TITLE
Fix typos.

### DIFF
--- a/cve.md
+++ b/cve.md
@@ -90,7 +90,7 @@ This vulnerability was discovered by Alexander Cherepanov <cherepan@mccme.ru>
 
 RubyGems provides the ability of a domain to direct clients to a separate
 host that is used to fetch gems and make API calls against. This mechanism
-is implemented via DNS, specificly a SRV record _rubygems._tcp under the
+is implemented via DNS, specifically a SRV record _rubygems._tcp under the
 original requested domain.
 
 For example, this is the one that users who use rubygems.org see:

--- a/run-your-own-gem-server.md
+++ b/run-your-own-gem-server.md
@@ -99,7 +99,7 @@ RubyGems mirror without having to push or write all gem you wanted in a
 configuration file try out [Gemirro](https://github.com/PierreRambaud/gemirro).
 It does mirroring without any authentication and you can add your private
 gems in the gems directory. More, to mirroring a source, you only need
-to start the server, and gems will automaticly be downloaded when needed.
+to start the server, and gems will automatically be downloaded when needed.
 
 To get started, install `gemirro`:
 

--- a/using-s3-source.md
+++ b/using-s3-source.md
@@ -38,7 +38,7 @@ You can generate all of them using one command: `gem generate_index`.
 
 ## Use with gem command
 
-> It's good practice to create a seperate IAM user with only read rights on the S3 bucket. Use a other IAM user for pushing the gems with write rights.
+> It's good practice to create a separate IAM user with only read rights on the S3 bucket. Use a other IAM user for pushing the gems with write rights.
 
 You can use your s3 source using `--source` flag:
 


### PR DESCRIPTION
While reading `run-your-own-gem-server.md` I noticed a typo, so I went looking for more. There are a few British vs American spelling things, eg "behaviour" vs "behavior", that I left alone.

Signed-off-by: Pete Higgins <pete@peterhiggins.org>