### PR TITLE
Fix invalid links being generated in the specification reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           repository: rubygems/rubygems
           path: rubygems
-          ref: v3.2.12
+          ref: 3.2
 
       - name: Build jekyll
         run: jekyll build

--- a/rdoc/generator/template/jekdoc/classpage.rhtml
+++ b/rdoc/generator/template/jekdoc/classpage.rhtml
@@ -8,7 +8,7 @@ next: /command-reference
 
 <% description = klass.description
    description.gsub! %r%<a\shref=(["'])Specification\.html#.*?\1>(.*?)</a>%m, '\2'
-   description.gsub! %r%<a\shref=(["'])Specification\.html\1>Specification</a>%,
+   description.gsub! %r%<a\shref=(["'])Specification\.html\1><code>Specification</code></a>%,
      'Specification' %>
 <%= description %>
 

--- a/specification-reference.md
+++ b/specification-reference.md
@@ -8,7 +8,7 @@ next: /command-reference
 
 
 
-<p>The <a href="Specification.html"><code>Specification</code></a> class contains the information for a gem.  Typically defined in a .gemspec file or a Rakefile, and looks like this:</p>
+<p>The Specification class contains the information for a gem.  Typically defined in a .gemspec file or a Rakefile, and looks like this:</p>
 
 <pre class="ruby"><span class="ruby-constant">Gem</span><span class="ruby-operator">::</span><span class="ruby-constant">Specification</span>.<span class="ruby-identifier">new</span> <span class="ruby-keyword">do</span> <span class="ruby-operator">|</span><span class="ruby-identifier">s</span><span class="ruby-operator">|</span>
   <span class="ruby-identifier">s</span>.<span class="ruby-identifier">name</span>        = <span class="ruby-string">&#39;example&#39;</span>
@@ -24,7 +24,7 @@ next: /command-reference
 <span class="ruby-keyword">end</span>
 </pre>
 
-<p>Starting in RubyGems 2.0, a <a href="Specification.html"><code>Specification</code></a> can hold arbitrary metadata.  See <code>metadata</code> for restrictions on the format and size of metadata items you may add to a specification.</p>
+<p>Starting in RubyGems 2.0, a Specification can hold arbitrary metadata.  See <code>metadata</code> for restrictions on the format and size of metadata items you may add to a specification.</p>
 
 
 


### PR DESCRIPTION
We have a custom template that eliminates some invalid links generated by RDoc. But the RDoc output changed, so it was no longer working.