### PR TITLE
Update docs relevant to help.rubygems.org

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -135,7 +135,7 @@
             <a class="nav--v__link--footer" href="https://rubygems.org/stats">Stats</a>
             <a class="nav--v__link--footer" href="http://blog.rubygems.org/">Blog</a>
             <a class="nav--v__link--footer" href="https://rubygems.org/pages/about">About</a>
-            <a class="nav--v__link--footer" href="http://help.rubygems.org/">Help</a>
+            <a class="nav--v__link--footer" href="mailto:support@rubygems.org">Help</a>
           </div>
           <div class="l-colspan--l colspan--l--has-border">
             <p class="footer__about">RubyGems.org is the Ruby community&rsquo;s gem hosting service. Instantly publish your gems and install them. Use the API to interact and find out more information about available gems. Become a contributor and enhance the site with your own changes.</p>

--- a/contributing.md
+++ b/contributing.md
@@ -72,11 +72,10 @@ Ruby's premier packaging system. Bundled with Ruby 1.9+ and available for Ruby 1
 * New features should be coupled with tests.
 * Ensure that your code blends well with ours (eg, no trailing whitespace, match indentation and coding style).
 * Don’t modify the history file or version number.
-* If you have any questions, just ask us on IRC in #rubygems or file [an issue][1].
+* If you have any questions, just ask us on [Bundler.io Slack][slack] or file [an issue][1].
 
-[0]: https://github.com/rubygems/rubygems
+[slack]: https://slack.bundler.io/
 [1]: https://github.com/rubygems/rubygems/issues
-[2]: http://help.rubygems.org
 
 <a class="project__name" href="https://github.com/rubygems/rubygems.org">RubyGems.org</a>
 

--- a/faqs.md
+++ b/faqs.md
@@ -17,13 +17,14 @@ frequently pop up.
 * [Why does `require 'some-gem'` fail?](#why-does-require-some-gem-fail)
 * [Why does require return false when loading a file from a gem?](#why-does-require-return-false-when-loading-a-file-from-a-gem)
 
-We also answer questions on the [RubyGems Support](http://help.rubygems.org/) site and on IRC
-in #rubygems. Some of the information you can find on the support site includes:
+We also answer questions on [Bundler.io Slack][slack].
+Some of the information you can find on the support site includes:
 
-* [Installing gems with no network](http://help.rubygems.org/kb/rubygems/installing-gems-with-no-network)
-* [Why do I get HTTP Response 302 or 301 when installing a gem?](http://help.rubygems.org/kb/rubygems/why-do-i-get-http-response-302-or-301-when-installing-a-gem)
-* [RubyGems Upgrade Issues](http://help.rubygems.org/kb/rubygems/rubygems-upgrade-issues)
+* [Installing gems with no network](https://help.rubygems.org/kb/rubygems/installing-gems-with-no-network)
+* [Why do I get HTTP Response 302 or 301 when installing a gem?](https://help.rubygems.org/kb/rubygems/why-do-i-get-http-response-302-or-301-when-installing-a-gem)
+* [RubyGems Upgrade Issues](https://help.rubygems.org/kb/rubygems/rubygems-upgrade-issues)
 
+[slack]: https://slack.bundler.io/
 I installed gems with `--user-install` and their commands are not available
 ---------------------------------------------------------------------------
 

--- a/name-your-gem.md
+++ b/name-your-gem.md
@@ -22,12 +22,11 @@ how to require the files in your gem. Following these conventions also lets
 Bundler require your gem with no extra configuration.
 
 If you publish a gem on [rubygems.org][rubygems] it may be removed if the name
-is objectionable, violates intellectual property or the contents of the gem
-meet these criteria.  You can report such a gem on the
-[RubyGems Support][rubygems-support] site.
+is objectionable, violates intellectual property or the contents of the gem meet
+these criteria.  You can report such a gem to [support@rubygems.org](mailto:support@rubygems.org)
+via email.
 
 [rubygems]: http://rubygems.org
-[rubygems-support]: http://help.rubygems.org
 
 Use underscores for multiple words
 ----------------------------------

--- a/rubygems-org-rate-limits.md
+++ b/rubygems-org-rate-limits.md
@@ -59,4 +59,5 @@ Following endpoints have rate limits of **300 requests/5 minutes** and **600 req
 * 10 request/10 minutes/email on password reset request - `POST /passwords`
 * 10 request/10 minutes/email on email confirmation request - `POST /email_confirmations`
 
-The RubyGems.org team may occasionally blackhole user IP addresses for extreme cases to protect the platform. If you think this has happened to you, please [submit a help ticket](https://help.rubygems.org/discussion/new), and we'll be happy to look at it.
+The RubyGems.org team may occasionally blackhole user IP addresses for extreme cases to protect the platform.
+If you think this has happened to you, please email to [support@rubygems.org](mailto:support@rubygems.org), and we'll be happy to look at it.


### PR DESCRIPTION
`https://help.rubygems.org/` now says `This help site has been deprecated. Please send your requests to support@rubygems.org`, so the relevant documentation should be removed to avoid to start a new request or question there.

When the link is preserved, the protocol is changed from http to https. New requests are to be sent to `support@rubygems.org`.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>