### PR TITLE
Fix help option parsing

### DIFF
--- a/command-reference.md
+++ b/command-reference.md
@@ -59,7 +59,7 @@ Build a gem from a gemspec
 * `--force`                     - skip validation of the spec
 * `--strict`                    - consider warnings as errors when validating the spec
 * `-o, --output FILE`               - output gem with the given filename
-* `-C` PATH                         - Run as if gem build was started in <PATH> instead of the current working directory.
+* `-C PATH`                         - Run as if gem build was started in <PATH> instead of the current working directory.
 
 ### Common Options
 

--- a/lib/options_list_markdownizer.rb
+++ b/lib/options_list_markdownizer.rb
@@ -36,11 +36,11 @@ class OptionsListMarkdownizer
   # Marks options mentioned on the given summary line
   def markdownize_options(line)
     # Mark options up as code (also prevents change of -- to &ndash;)
-    option_line_re = /^(\s*)((-\w, )*--[^\s]+)( [A-Za-z_\[\],]+)*(\s{3,})(.+)/
+    option_line_re = /^(\s*)((?:-\w, )*--[^\s]+)( [A-Za-z_\[\],]+)*(\s{3,})(.+)/
     if option_line_re =~ line
       line.sub(option_line_re) do |m|
-        "#{$1}`#{$2}#{$4}`#{$5}" +
-          markdownize_inline_options($6)
+        "#{$1}`#{$2}#{$3}`#{$4}" +
+          markdownize_inline_options($5)
       end
     else
       markdownize_inline_options(line)

--- a/lib/options_list_markdownizer.rb
+++ b/lib/options_list_markdownizer.rb
@@ -36,11 +36,11 @@ class OptionsListMarkdownizer
   # Marks options mentioned on the given summary line
   def markdownize_options(line)
     # Mark options up as code (also prevents change of -- to &ndash;)
-    option_line_re = /^(\s*)((?:-\w, )*--[^\s]+)( [A-Za-z_\[\],]+)*(\s{3,})(.+)/
+    option_line_re = /^(\s*)((?:--[^\s]+|-[^\s])(?:, (?:--[^\s]+|-[^\s]))*(?: [A-Za-z_\[\],]+)*)(\s{3,})(.+)/
     if option_line_re =~ line
       line.sub(option_line_re) do |m|
-        "#{$1}`#{$2}#{$3}`#{$4}" +
-          markdownize_inline_options($5)
+        "#{$1}`#{$2}`#{$3}" +
+          markdownize_inline_options($4)
       end
     else
       markdownize_inline_options(line)

--- a/spec/options_list_markdownizer_spec.rb
+++ b/spec/options_list_markdownizer_spec.rb
@@ -65,6 +65,11 @@ describe OptionsListMarkdownizer do
       "                                     and the certificate from `-C`\n",
       'short option in description continuation',
     ],
+    [
+      "    -C PATH                      Run as if gem build was started in <PATH> instead of the current working directory.\n",
+      "    `-C PATH`                      Run as if gem build was started in <PATH> instead of the current working directory.\n",
+      'short option only with argument',
+    ],
   ].each do |given,expected,description|
     it (description || given) do
       expected = given if expected.nil?


### PR DESCRIPTION
To allow single short options with arguments.

Fixes #288.