### PR TITLE
rubygems-org-api: include information about the use of the OTP header

### DIFF
--- a/rubygems-org-api.md
+++ b/rubygems-org-api.md
@@ -35,6 +35,13 @@ using an API key:
 
     $ curl -H 'Authorization:YOUR_API_KEY' \
       https://rubygems.org/api/v1/some_api_call.json
+      
+If you are using Multi-factor authentication, you will need to provide one-time passcode
+in the `OTP` header. Here's an example of using your API key with a OTP:
+
+    $ curl -H 'Authorization:YOUR_API_KEY' \
+           -H 'OTP:YOUR_ONE_TIME_PASSCODE' \
+      https://rubygems.org/api/v1/some_api_call.json
 
 Ruby Library
 ------------


### PR DESCRIPTION
In order to authenticate using an account with Multi-factor authentication enabled, the API request will need to send a one-time passcode in the OTP HTTP header.

Relevant code: 

https://github.com/rubygems/rubygems.org/blob/f9f246e31140df003ee5b0c1228e87579b0b1286/app/controllers/api/v1/api_keys_controller.rb#L53

and 

https://github.com/rubygems/rubygems.org/blob/f9f246e31140df003ee5b0c1228e87579b0b1286/app/controllers/api/v1/api_keys_controller.rb#L77-L79