### PR TITLE
Move 'required_ruby_version' attribute to recommended.

### DIFF
--- a/specification-reference.md
+++ b/specification-reference.md
@@ -53,6 +53,11 @@ next: /command-reference
 * [licenses=](#licenses=)
     
 * [metadata](#metadata)
+
+* [required_ruby_version](#required_ruby_version)
+
+* [required_ruby_version=](#required_ruby_version=)
+
     
 ## Optional gemspec attributes
     
@@ -79,10 +84,6 @@ next: /command-reference
 * [rdoc_options](#rdoc_options)
     
 * [require_paths=](#require_paths=)
-    
-* [required_ruby_version](#required_ruby_version)
-    
-* [required_ruby_version=](#required_ruby_version=)
     
 * [required_rubygems_version](#required_rubygems_version)
     


### PR DESCRIPTION
related to https://github.com/rubygems/rfcs/pull/26 and https://github.com/rubygems/rfcs/issues/34

What about to start with this simple improvement @marcandre? We can make it required later.

---

![rec](https://user-images.githubusercontent.com/193936/138618959-141c9e9c-5730-40df-b40f-f3ebe5034388.png)
