### PR TITLE
Notice of unique gem name when publishing

### DIFF
--- a/publishing.md
+++ b/publishing.md
@@ -80,6 +80,9 @@ After creating the account, use your email and password when pushing the gem.
 (RubyGems saves the credentials in ~/.gem/credentials for you so you only need
 to log in once.)
 
+Note that your gem name must be unique. It cannot have a name that is already
+in use from another gem alrady published in [RubyGems.org](https://rubygems.org/).
+
 To publish version 0.1.0 of a new gem named 'squid-utils':
 
     $ gem push squid-utils-0.1.0.gem


### PR DESCRIPTION
- Added notice that, when publishing a gem, the name must be unique and not already in use. 
Took me a while to understand why I could not push my gem and found out this was the reason why. Could not find this notice anywhere else in docs. Hopefully, this will help others in the future!