### PR TITLE
Use Bundler with a lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,6 @@ jobs:
   ci:
     runs-on: ubuntu-20.04
     steps:
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7.2
-
-      - name: Install dependencies
-        run: |
-          gem install jekyll
-          gem install mdl
-
       - uses: actions/checkout@v2
         with:
           path: guides
@@ -28,14 +18,21 @@ jobs:
           path: rubygems
           ref: 3.3
 
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.2
+          bundler-cache: true
+          working-directory: guides
+
       - name: Build jekyll
-        run: jekyll build
+        run: bundle exec jekyll build
         working-directory: guides
 
       - name: Generate command guide
-        run: RUBYOPT="--disable-gems -I../rubygems/lib" rake command_guide && git diff --exit-code
+        run: RUBYOPT="--disable-gems -I../rubygems/lib" bundle exec rake command_guide && git diff --exit-code
         working-directory: guides
 
       - name: Lint generated markdown
-        run: mdl --rules MD009,MD012 command-reference.md
+        run: bundle exec mdl --rules MD009,MD012 command-reference.md
         working-directory: guides

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.2"
+gem "mdl", "~> 0.11.0"
+gem "rdoc", "~> 6.3"
+gem "rake", "~> 13.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,91 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    chef-utils (17.9.26)
+      concurrent-ruby
+    colorator (1.1.0)
+    concurrent-ruby (1.1.9)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.15.5)
+    forwardable-extended (2.6.0)
+    http_parser.rb (0.8.0)
+    i18n (1.8.11)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.2.1)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (~> 2.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.4.0)
+      pathutil (~> 0.9)
+      rouge (~> 3.0)
+      safe_yaml (~> 1.0)
+      terminal-table (~> 2.0)
+    jekyll-sass-converter (2.1.0)
+      sassc (> 2.0.1, < 3.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    kramdown (2.3.1)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.3)
+    listen (3.7.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mdl (0.11.0)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      mixlib-cli (~> 2.1, >= 2.1.1)
+      mixlib-config (>= 2.2.1, < 4)
+      mixlib-shellout
+    mercenary (0.4.0)
+    mixlib-cli (2.1.8)
+    mixlib-config (3.0.9)
+      tomlrb
+    mixlib-shellout (3.2.5)
+      chef-utils
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    psych (4.0.3)
+      stringio
+    public_suffix (4.0.6)
+    rake (13.0.6)
+    rb-fsevent (0.11.0)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rdoc (6.4.0)
+      psych (>= 4.0.0)
+    rexml (3.2.5)
+    rouge (3.27.0)
+    safe_yaml (1.0.5)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    stringio (3.0.1)
+    terminal-table (2.0.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
+    tomlrb (2.0.1)
+    unicode-display_width (1.8.0)
+
+PLATFORMS
+  arm64-darwin-21
+  x86_64-linux
+
+DEPENDENCIES
+  jekyll (~> 4.2)
+  mdl (~> 0.11.0)
+  rake (~> 13.0)
+  rdoc (~> 6.3)
+
+BUNDLED WITH
+   2.3.4

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ straight up markdown page, so just go edit it!
 For the Command Guide (`command-reference.md`), edit `command-reference.erb`
 and run:
 
-    $ rake command_guide
+    $ bundle exec rake command_guide
 
 For the Specification Guide, the documentation comes directly from the
 `Gem::Specification` class in RubyGems. Edit it, set your `RUBYGEMS_DIR` to
 where your code directory is, and run:
 
-    $ RUBYGEMS_DIR=~/Dev/ruby/rubygems rake spec_guide --trace
+    $ RUBYGEMS_DIR=~/Dev/ruby/rubygems bundle exec rake spec_guide --trace
 
 Thanks
 ------

--- a/specification-reference.md
+++ b/specification-reference.md
@@ -105,7 +105,7 @@ next: /command-reference
 
 <p>A list of authors for this gem.</p>
 
-<p>Alternatively, a single author can be specified by assigning a string to ‘spec.author`</p>
+<p>Alternatively, a single author can be specified by assigning a string to <code>spec.author</code></p>
 
 <p>Usage:</p>
 
@@ -150,7 +150,7 @@ next: /command-reference
 
 ## summary
 
-<p>A short summary of this gem’s description.  Displayed in ‘gem list -d`.</p>
+<p>A short summary of this gem’s description.  Displayed in <code>gem list -d</code>.</p>
 
 <p>The <code>description</code> should be more detailed than the summary.</p>
 


### PR DESCRIPTION
To avoid third party changes in dependencies to affect us, like it happened with RDoc recently.