### PR TITLE
Allow / as a separator for options

### DIFF
--- a/command-reference.md
+++ b/command-reference.md
@@ -614,7 +614,7 @@ Install a gem into the local repository
 * `--without GROUPS`            - Omit the named groups (comma separated) when installing from a gem dependencies file
 * `--default`                   - Add the gem's full specification to specifications/default and extract only its bin
 * `--explain`                   - Rather than install the gems, indicate which would be installed
-* `--[no-]lock`                 - Create a lock file (when used with `-g`/--file)
+* `--[no-]lock`                 - Create a lock file (when used with `-g`/`--file`)
 * `--[no-]suggestions`          - Suggest alternates when gems are not found
 
 ### Local/Remote Options
@@ -996,7 +996,7 @@ Restores installed gems to pristine condition from files located in the gem cach
 ### Options
 
 * `--all`                       - Restore all installed gems to pristine condition
-* `--skip=gem_name`             - used on `--all,` skip if name == gem_name
+* `--skip=gem_name`             - used on `--all`, skip if name == gem_name
 * `--[no-]extensions`           - Restore gems with extensions in addition to regular gems
 * `--only-executables`          - Only restore executables
 * `--only-plugins`              - Only restore plugins
@@ -1608,7 +1608,7 @@ Update installed gems to the latest version
 * `--without GROUPS`            - Omit the named groups (comma separated) when installing from a gem dependencies file
 * `--default`                   - Add the gem's full specification to specifications/default and extract only its bin
 * `--explain`                   - Rather than install the gems, indicate which would be installed
-* `--[no-]lock`                 - Create a lock file (when used with `-g`/--file)
+* `--[no-]lock`                 - Create a lock file (when used with `-g`/`--file`)
 * `--[no-]suggestions`          - Suggest alternates when gems are not found
 
 ### Local/Remote Options

--- a/lib/options_list_markdownizer.rb
+++ b/lib/options_list_markdownizer.rb
@@ -50,6 +50,6 @@ class OptionsListMarkdownizer
   private
 
   def markdownize_inline_options(line)
-    line.gsub(/(?<=\s)(--[^\s]+|-[^\s])/, '`\1`')
+    line.gsub(/(?<=[\s\/])(--[\w\[\]\-]+|-\w)/, '`\1`')
   end
 end

--- a/spec/options_list_markdownizer_spec.rb
+++ b/spec/options_list_markdownizer_spec.rb
@@ -51,8 +51,8 @@ describe OptionsListMarkdownizer do
       'short option and boolean switch long',
     ],
     [
-      "    -K, --private-key KEY            Key for --sign or --build\n",
-      "    `-K, --private-key KEY`            Key for `--sign` or `--build`\n",
+      "    -K, --private-key KEY            Key for --sign or --build. -g/--file can be used.\n",
+      "    `-K, --private-key KEY`            Key for `--sign` or `--build`. `-g`/`--file` can be used.\n",
       'long option in description',
     ],
     [


### PR DESCRIPTION
https://guides.rubygems.org/command-reference/#gem-install and https://guides.rubygems.org/command-reference/#gem-update should highlight `--file` in description, which is located just before `/`. This also prevents to include `,` in option strings like `--all,`.

## Generated Markdown
### before
```
* `--[no-]lock`                 - Create a lock file (when used with `-g`/--file)
```
### after
```
* `--[no-]lock`                 - Create a lock file (when used with `-g`/`--file`)
```

## Generated HTML code
### before this change
```html
<li><code class="language-plaintext highlighter-rouge">--[no-]lock</code>                 - Create a lock file (when used with <code class="language-plaintext highlighter-rouge">-g</code>/–file)</li>
```
### after this change
```html
<li><code class="language-plaintext highlighter-rouge">--[no-]lock</code>                 - Create a lock file (when used with <code class="language-plaintext highlighter-rouge">-g</code>/<code class="language-plaintext highlighter-rouge">–file</code>)</li>
```



Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>