### PR TITLE
Update Ruby from 2.7 to 3.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.2
+          ruby-version: 3.1.2
           bundler-cache: true
           working-directory: guides
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.2"
 gem "mdl", "~> 0.11.0"
-gem "rdoc", "~> 6.3"
 gem "rake", "~> 13.0"
+gem "rdoc", "~> 6.3"
+gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       unicode-display_width (~> 1.1, >= 1.1.1)
     tomlrb (2.0.1)
     unicode-display_width (1.8.0)
+    webrick (1.7.0)
 
 PLATFORMS
   arm64-darwin-21
@@ -86,6 +87,7 @@ DEPENDENCIES
   mdl (~> 0.11.0)
   rake (~> 13.0)
   rdoc (~> 6.3)
+  webrick (~> 1.7)
 
 BUNDLED WITH
-   2.3.4
+   2.3.7


### PR DESCRIPTION
Update Ruby from 2.7.2 to 3.1.2 on CI as well as development.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)