### PR TITLE
Update TODOs described in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ Want to help?
 If a guide is empty, start filling it out! Or, make a new one! Pull requests
 are gladly accepted!
 
-* Port content from docs.rubygems.org
-* Port content from rubygems.org/pages/docs
+* Pick one from [the repo issues](https://github.com/rubygems/guides/issues)
 * Port content from help.rubygems.org knowledge base
 * Find lots of StackOverflow/ruby-talk questions and get their common answers in here
 * Fill out more guides!


### PR DESCRIPTION
Historical web resources were already removed, most of which weremigrated appropriately:

- `rubygems.org/pages/docs`:
   - https://web.archive.org/web/20100226145752/rubygems.org/pages/docs
- `http://docs.rubygems.org/`:
   - https://web.archive.org/web/20120112162234/http://docs.rubygems.org/

Updates 591ad56bab30d61911bcf4daa8923cacef4b69a7 (11 years ago)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)