### PR TITLE
Add .gitpod.yml to make dev env easier 

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,8 @@
+image: gitpod/workspace-ruby-3.1
+tasks:
+  - init: |
+      # Code fetch for generating command guide into /workspace/rubygems
+      git clone --depth 1 -b 3.3 https://github.com/rubygems/rubygems.git ../rubygems
+      bundle config set path vendor/bundle
+      bundle install
+    command: bundle exec jekyll serve


### PR DESCRIPTION
`gem install jekyll` (regardless use of Bundler) looks very slow, which spoils contributor experience on this repo. With [Gitpod](https://www.gitpod.io/) and [its prebuilds](https://www.gitpod.io/docs/prebuilds) feature, a new contributor would focus on what they want to improve.

- [x] Blocked by #317

## How to test

1. Prepare your account in Gitpod.io (free use for 25 hours a month for everyone)
2. Access to https://gitpod.io/#github.com/tnir/guides/tree/gitpod to launch your workspace
3. Develop anything as usual
4. Stop the running workspace
5. And restart the workspace
6. Check if jekyll starts properly (sometimes fails if the settings is not perfectly configured on Gitpod)
7. Develop anything as usual again

## Resources
- Lifecycle of Gitpod workspace: https://www.gitpod.io/docs/release-notes/2019-02-15/february-2019#lifecycles

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)