### PR TITLE
Use the latest jQuery (3.6.0)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Keywords" name="Keywords" content="rubygems, gems, programming, ruby, packages" />
     <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" name="viewport">
     <link href="/stylesheets/application.css" rel="stylesheet" type="text/css" />
-    <script src="//code.jquery.com/jquery-2.1.1.min.js"></script>
+    <script src="//code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="/javascripts/mobile-nav.js" type="text/javascript"></script>
     <script src="//use.typekit.net/omu5dik.js" type="text/javascript"></script>
     <script>


### PR DESCRIPTION
Updates jQuery from 2.1.1 to 3.6.0.


Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)