### PR TITLE
Update header menu links

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -60,9 +60,10 @@
           </form>
 
           <nav class="header__nav-links">
+            <a class="header__nav-link" href="https://rubygems.org/releases">Releases</a>
+            <a class="header__nav-link" href="https://blog.rubygems.org">Blog</a>
             <a class="header__nav-link" href="https://rubygems.org/gems">Gems</a>
             <a class="header__nav-link is-active" href="/">Guides</a>
-            <a class="header__nav-link" href="https://blog.rubygems.org">Blog</a>
             <a class="header__nav-link" href="/contributing">Contribute</a>
           </nav>
         </div>


### PR DESCRIPTION
Update header menu links to more closely match rubygems.org, as outlined here:

[**RubyGems features:** UI Issue: Make Header Menu Consistent on Blog/Guides SubSites](https://github.com/orgs/rubygems/projects/6/views/1?pane=issue&itemId=18722655)