### PR TITLE
Update API v2 doc to mention platform query parameter

### DIFF
--- a/rubygems-org-api-v2.md
+++ b/rubygems-org-api-v2.md
@@ -12,7 +12,10 @@ Gem Version Methods
 
 ### GET - `/api/v2/rubygems/[GEM NAME]/versions/[VERSION NUMBER].(json|yaml)`
 
-Returns a dictionary with versions details for a specific gem version. Example:
+Returns a dictionary with versions details for a specific gem version.
+
+To return the version for a specific platform (e.g. "ruby", "java", "x86_64-linux"), use the `platform` query parameter. 
+
 
     $ curl https://rubygems.org/api/v2/rubygems/coulda/versions/0.7.1.json
 


### PR DESCRIPTION
https://github.com/rubygems/rubygems.org/pull/1748 introduced the ability to query for a specific platform for a given version on the API v2.

However, this capability is not documented in the guide for this API endpoint.

This change updates the docs to mention this query parameter.

Signed-off-by: Caleb Brown <calebbrown@google.com>