### PR TITLE
Remove no Safari Webauthn CLI support warning

### DIFF
--- a/setting-up-webauthn-mfa.md
+++ b/setting-up-webauthn-mfa.md
@@ -46,10 +46,6 @@ click "Other Options" to use a hardware token. Other browsers may vary.
 6. You will now see your security device on the screen above the Nickname
 field.
 
-**Note**: While Safari can be used for logging into the web UI using WebAuthn,
-it does not work for logging in with the CLI. This is due to Safari
-[failing to implement a necessary feature](https://bugs.webkit.org/show_bug.cgi?id=171934).
-
 ## Dealing with lost devices
 
 WebAuthn often depends on a connection with the physical device

--- a/using-webauthn-mfa-in-command-line.md
+++ b/using-webauthn-mfa-in-command-line.md
@@ -38,10 +38,6 @@ A webpage titled "Authenticate with Security Device" appears. Click "Authenticat
 Your browser will show a popup asking you to use a Passkey or other authentication
 device (the exact popup will vary according to the browser).
 
-**Note**: currently, [Safari does not implement a feature](https://bugs.webkit.org/show_bug.cgi?id=171934)
-required for the WebAuthn CLI to work. You must use another browser for WebAuthn CLI
-authentication. If you try to use Safari you will see a warning on this page.
-
 Once you have authenticated using your WebAuthn device device, you will see a
 "Success" page. At this point you can close your browser tab and return to the
 command line, which will say:


### PR DESCRIPTION
Part of: https://github.com/rubygems/rubygems.org/issues/3826
This reverts commit 7749a910595dd509accf1332bd976dd05370f3ff.

There are a couple PRs up to add Webauthn CLI support for Safari browsers (https://github.com/rubygems/rubygems.org/pull/3873, https://github.com/rubygems/rubygems/pull/6774). 

Once those are released, we can remove the warning in the guides. **Currently blocked**