### PR TITLE
Add missing end quote on rubygems security guide checksum verify commands

### DIFF
--- a/security.md
+++ b/security.md
@@ -62,7 +62,7 @@ Install with a trust policy.
 Verify the checksum, if available
 
     gem fetch gemname -v version
-    ruby -rdigest/sha2 -e "puts Digest::SHA512.new.hexdigest(File.read('gemname-version.gem'))
+    ruby -rdigest/sha2 -e "puts Digest::SHA512.new.hexdigest(File.read('gemname-version.gem'))"
 
 Know the risks of being pwned, as described by [Benjamin Smith's Hacking with Gems talk](https://youtu.be/zEBReauO-vg)
 


### PR DESCRIPTION
This page has a missing end quote in commands to verify the checksum 

Old:
```
$ ruby -rdigest/sha2 -e "puts Digest::SHA512.new.hexdigest(File.read('<MyGems>.gem'))
> ^C
```

New:
```
$ ruby -rdigest/sha2 -e "puts Digest::SHA512.new.hexdigest(File.read('<MyGems>.gem'))"
006.................................................
```

Thanks.