### PR TITLE
Update bindir from bin to exe

### DIFF
--- a/specification-reference.md
+++ b/specification-reference.md
@@ -344,11 +344,11 @@ next: /command-reference
 
 ## bindir
 
-<p>The path in the gem for executable scripts.  Usually ‘bin’</p>
+<p>The path in the gem for executable scripts.  Usually ‘exe’</p>
 
 <p>Usage:</p>
 
-<pre class="ruby"><span class="ruby-identifier">spec</span>.<span class="ruby-identifier">bindir</span> = <span class="ruby-string">&#39;bin&#39;</span>
+<pre class="ruby"><span class="ruby-identifier">spec</span>.<span class="ruby-identifier">bindir</span> = <span class="ruby-string">&#39;exe&#39;</span>
 </pre>
 
 <a id="cert_chain"> </a>


### PR DESCRIPTION
Bundler uses the `exe` directory by default, so match the description in the document.

> --exe or -b or --bin: Specify that Bundler should create a binary executable (as exe/GEM_NAME) in the generated rubygem project.
> refs: `bundle gem --help`