### PR TITLE
Use squiggly heredoc for gem description example

### DIFF
--- a/specification-reference.md
+++ b/specification-reference.md
@@ -189,7 +189,7 @@ next: /command-reference
 
 <p>Usage:</p>
 
-<pre class="ruby"><span class="ruby-identifier">spec</span>.<span class="ruby-identifier">description</span> = <span class="ruby-identifier">&lt;&lt;-EOF</span>
+<pre class="ruby"><span class="ruby-identifier">spec</span>.<span class="ruby-identifier">description</span> = <span class="ruby-identifier">&lt;&lt;~EOF</span>
 <span class="ruby-value">  Rake is a Make-like program implemented in Ruby. Tasks and
   dependencies are specified in standard Ruby syntax.
 </span><span class="ruby-identifier">EOF</span>


### PR DESCRIPTION
## Motivation

Using a non-squiggly heredoc adds leading whitespace in the gem description. [rubygems.org](https://rubygems.org/) seems to handle this fine (by relying on HTML ignoring it), but in other contexts it can make it difficult to render the text (e.g. [in an editor using an LSP](https://github.com/Shopify/ruby-lsp/pull/1279)).

I believe the squiggly heredoc is supported on all non-EOL Ruby versions, but I could understand rejecting this change because it might make it impossible to install a gem on EOL versions. Still, felt it was worth opening here.