### PR TITLE
Fix broken link to Nokogiri gem in documentation

### DIFF
--- a/make-your-own-gem.md
+++ b/make-your-own-gem.md
@@ -296,7 +296,7 @@ Adding an executable
 In addition to providing libraries of Ruby code, gems can also expose one or
 many executable files to your shell's `PATH`. Probably the best known example
 of this is `rake`. Another very useful one is `nokogiri` from [Nokogiri
-](https://rubygems.org/gems/Nokogiri) gem, which parse HTML/XML documents.
+](https://rubygems.org/gems/nokogiri) gem, which parse HTML/XML documents.
 Here's an example:
 
     $ gem install -N nokogiri


### PR DESCRIPTION
## Description
Thank you for your continued support.
While reading through the documentation, I noticed a broken link.

This PR updates a broken link in the documentation, pointing now to the correct Nokogiri gem page on RubyGems.
(The previous link was resulting in a 404 error)

## Changes
- Updated the URL to https://rubygems.org/gems/nokogiri in the relevant documentation file.