### PR TITLE
Fix broken links to ruby-docs.org replacing them with the official docs

### DIFF
--- a/gems-with-extensions.md
+++ b/gems-with-extensions.md
@@ -272,7 +272,7 @@ Further Reading
   and [part 2](http://tenderlovemaking.com/2010/12/11/writing-ruby-c-extensions-part-2.html))
   by Aaron Patterson
 * Interfaces to C libraries can be written using ruby and
-  [fiddle](https://ruby-doc.org/stdlib/libdoc/fiddle/rdoc/Fiddle.html) (part
+  [fiddle](https://docs.ruby-lang.org/en/master/Fiddle.html) (part
   of the standard library) or [ruby-ffi](https://github.com/ffi/ffi)
 * [Extending Ruby](http://ruby-doc.com/docs/ProgrammingRuby/html/ext_ruby.html)
   is a [Programming Ruby](http://docs.ruby-doc.com/docs/ProgrammingRuby/)

--- a/patterns.md
+++ b/patterns.md
@@ -273,8 +273,8 @@ For example, let's say we have a `foo` gem with the following structure:
 This might seem harmless since your custom `erb` and `set` files are within
 your gem.  However, this is not harmless, anyone who requires this gem will not
 be able to bring in the
-[ERB](http://ruby-doc.org/stdlib/libdoc/erb/rdoc/classes/ERB.html) or
-[Set](http://www.ruby-doc.org/stdlib/libdoc/set/rdoc/classes/Set.html) classes
+[ERB](https://docs.ruby-lang.org/en/master/ERB.html) or
+[Set](https://docs.ruby-lang.org/en/master/Set.html) classes
 provided by Ruby's standard library.
 
 The best way to get around this is to keep files in a different directory


### PR DESCRIPTION
These links are broken today. I'm replacing them with the official documentation from ruby-lang.org