### PR TITLE
Improve site navigation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,14 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.5)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    bigdecimal (3.1.8)
+    bigdecimal (3.1.8-java)
     chef-utils (17.9.26)
       concurrent-ruby
     colorator (1.1.0)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -14,21 +16,29 @@ GEM
     eventmachine (1.2.7-java)
     ffi (1.16.3)
     ffi (1.16.3-java)
-    ffi-compiler (1.0.1)
-      ffi (>= 1.0.0)
+    ffi-compiler (1.3.2)
+      ffi (>= 1.15.5)
       rake
     forwardable-extended (2.6.0)
-    google-protobuf (3.25.1)
-    google-protobuf (3.25.1-arm64-darwin)
-    google-protobuf (3.25.1-java)
+    google-protobuf (4.27.0)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.27.0-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.27.0-java)
+      bigdecimal
       ffi (~> 1)
       ffi-compiler (~> 1)
-    google-protobuf (3.25.1-x86_64-linux)
+      rake (>= 13)
+    google-protobuf (4.27.0-x86_64-linux)
+      bigdecimal
+      rake (>= 13)
     http_parser.rb (0.8.0)
-    i18n (1.14.1)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     jar-dependencies (0.4.1)
-    jekyll (4.3.2)
+    jekyll (4.3.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -53,7 +63,7 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.4)
-    listen (3.8.0)
+    listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mdl (0.11.0)
@@ -74,26 +84,26 @@ GEM
       stringio
     psych (5.1.2-java)
       jar-dependencies (>= 0.1.7)
-    public_suffix (5.0.4)
-    rake (13.0.6)
+    public_suffix (5.0.5)
+    rake (13.2.1)
     rb-fsevent (0.11.2)
-    rb-inotify (0.10.1)
+    rb-inotify (0.11.1)
       ffi (~> 1.0)
     rdoc (6.4.1.1)
       psych (>= 4.0.0)
     rexml (3.2.8)
       strscan (>= 3.0.9)
-    rouge (4.2.0)
+    rouge (4.2.1)
     safe_yaml (1.0.5)
-    sass-embedded (1.69.5)
-      google-protobuf (~> 3.23)
+    sass-embedded (1.77.2)
+      google-protobuf (>= 3.25, < 5.0)
       rake (>= 13.0.0)
-    sass-embedded (1.69.5-arm-linux-gnueabihf)
-      google-protobuf (~> 3.23)
-    sass-embedded (1.69.5-arm64-darwin)
-      google-protobuf (~> 3.23)
-    sass-embedded (1.69.5-x86_64-linux-gnu)
-      google-protobuf (~> 3.23)
+    sass-embedded (1.77.2-arm-linux-gnueabihf)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.2-arm64-darwin)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.2-x86_64-linux-gnu)
+      google-protobuf (>= 3.25, < 5.0)
     stringio (3.1.0)
     strscan (3.1.0)
     strscan (3.1.0-java)
@@ -101,7 +111,7 @@ GEM
       unicode-display_width (>= 1.1.1, < 3)
     tomlrb (2.0.1)
     unicode-display_width (2.5.0)
-    webrick (1.7.0)
+    webrick (1.8.1)
 
 PLATFORMS
   arm64-darwin
@@ -118,4 +128,4 @@ DEPENDENCIES
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.4.22
+   2.5.11

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -89,7 +89,6 @@
               <li><a class="nav--v__link" href="/patterns">Patterns</a></li>
               <li><a class="nav--v__link" href="/specification-reference">Specification Reference</a></li>
               <li><a class="nav--v__link" href="/command-reference">Command Reference</a></li>
-              <li><a class="nav--v__link" href="https://docs.seattlerb.org/rubygems">RubyGems API</a></li>
               <li><a class="nav--v__link" href="/rubygems-org-api">RubyGems.org API</a></li>
               <li><a class="nav--v__link" href="/rubygems-org-api-v2">RubyGems.org API V2.0</a></li>
               <li><a class="nav--v__link" href="/rubygems-org-rate-limits">RubyGems.org rate limits</a></li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -91,6 +91,7 @@
               <li><a class="nav--v__link" href="/command-reference">Command Reference</a></li>
               <li><a class="nav--v__link" href="/rubygems-org-api">RubyGems.org API</a></li>
               <li><a class="nav--v__link" href="/rubygems-org-api-v2">RubyGems.org API V2.0</a></li>
+              <li><a class="nav--v__link" href="/rubygems-org-compact-index-api">RubyGems.org Compact Index API</a></li>
               <li><a class="nav--v__link" href="/rubygems-org-rate-limits">RubyGems.org rate limits</a></li>
               <li><a class="nav--v__link" href="/api-key-scopes">API key scopes</a></li>
               <li><a class="nav--v__link" href="/run-your-own-gem-server">Run your own gem server</a></li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -111,7 +111,6 @@
               <li><a class="nav--v__link" href="/contributing">Contributing to RubyGems</a></li>
               <li><a class="nav--v__link" href="/faqs">Frequently Asked Questions</a></li>
               <li><a class="nav--v__link" href="/plugins">Plugins</a></li>
-              <li><a class="nav--v__link" href="/credits">Credits</a></li>
               <li><a class="nav--v__link" href="/cve">Common Vulnerabilities and Exposures</a></li>
               <li><a class="nav--v__link" href="/releasing-rubygems">Releasing RubyGems</a></li>
               <li><a class="nav--v__link" href="/trusted-publishing">Trusted Publishing</a></li>
@@ -120,6 +119,7 @@
                 <li><a class="nav--v__link" href="/trusted-publishing/pushing-a-new-gem">Pushing a new gem</a></li>
                 <li><a class="nav--v__link" href="/trusted-publishing/releasing-gems">Releasing gems</a></li>
               </ul>
+              <li><a class="nav--v__link" href="/credits">Credits</a></li>
 
             </ul>
           </div>

--- a/credits.md
+++ b/credits.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Credits
-previous: /plugins
+previous: /trusted-publishing/releasing-gems
 next: /
 ---
 

--- a/cve.md
+++ b/cve.md
@@ -2,6 +2,8 @@
 layout: default
 title: RubyGems Common Vulnerabilities and Exposures
 url: /cve
+previous: /credits
+next: /releasing-rubygems
 ---
 
 # RubyGems Common Vulnerabilities and Exposures

--- a/mfa-requirement-opt-in.md
+++ b/mfa-requirement-opt-in.md
@@ -2,7 +2,7 @@
 layout: default
 title: MFA requirement opt-in
 url: /mfa-requirement-opt-in
-previous: /using-mfa-in-command-line
+previous: /using-otp-mfa-in-command-line
 next: /using-s3-source
 ---
 <em class="t-gray">How to opt-in for MFA requirement.</em>

--- a/plugins.md
+++ b/plugins.md
@@ -3,7 +3,7 @@ layout: default
 title: Plugins
 url: /plugins
 previous: /faqs
-next: /credits
+next: /cve
 ---
 
 Plugins

--- a/releasing-rubygems.md
+++ b/releasing-rubygems.md
@@ -2,6 +2,8 @@
 layout: default
 title: Releasing Rubygems
 url: /releasing-rubygems
+previous: /cve
+next: /trusted-publishing
 ---
 
 <em class="t-gray">A runbook for making RubyGems releases.</em>

--- a/ssl-certificate-update.md
+++ b/ssl-certificate-update.md
@@ -2,7 +2,7 @@
 layout: default
 title: SSL Certificate Update
 url: /ssl-certificate-update
-previous: /security
+previous: /removing-a-published-gem
 next: /patterns
 ---
 

--- a/trusted-publishing.md
+++ b/trusted-publishing.md
@@ -2,6 +2,8 @@
 layout: default
 title: Trusted Publishing
 url: /trusted-publishing
+previous: /releasing-rubygems
+next: /trusted-publishing/adding-a-publisher
 ---
 
 Trusted Publishing is a term for using OpenID Connect (OIDC) to exchange short-lived identity tokens between a trusted third-party service and RubyGems.org.

--- a/trusted-publishing/adding-a-publisher.md
+++ b/trusted-publishing/adding-a-publisher.md
@@ -2,6 +2,8 @@
 layout: default
 title: Adding a trusted publisher to an existing gem
 url: /trusted-publishing/adding-a-publisher
+previous: /trusted-publishing
+next: /trusted-publishing/pushing-a-new-gem
 ---
 
 Adding a trusted publisher to a gem only requires a single setup step.

--- a/trusted-publishing/pushing-a-new-gem.md
+++ b/trusted-publishing/pushing-a-new-gem.md
@@ -2,6 +2,8 @@
 layout: default
 title: Pushing a new gem with a trusted publisher
 url: /trusted-publishing/pushing-a-new-gem
+previous: /trusted-publishing/adding-a-publisher
+next: /trusted-publishing/releasing-gems
 ---
 
 Trusted publishers are not just for existing gems, they can also be used to push new gems!

--- a/trusted-publishing/releasing-gems.md
+++ b/trusted-publishing/releasing-gems.md
@@ -2,6 +2,7 @@
 layout: default
 title: Releasing gems with a trusted publisher
 url: /trusted-publishing/releasing-gems
+next: /credits
 ---
 
 Once you have a trusted publisher configured, you can use RubyGems' [`release-gem`](https://github.com/rubygems/release-gem) GitHub Action to set up your workflow to push gems to RubyGems.org.

--- a/trusted-publishing/releasing-gems.md
+++ b/trusted-publishing/releasing-gems.md
@@ -2,6 +2,7 @@
 layout: default
 title: Releasing gems with a trusted publisher
 url: /trusted-publishing/releasing-gems
+previous: /trusted-publishing/pushing-a-new-gem
 next: /credits
 ---
 

--- a/using-mfa-in-command-line.md
+++ b/using-mfa-in-command-line.md
@@ -2,7 +2,7 @@
 layout: default
 title: Using multi-factor authentication in command line
 url: /using-mfa-in-command-line
-previous: /setting-up-multifactor-authentication
+previous: /setting-up-otp-mfa
 next: /using-webauthn-mfa-in-command-line
 ---
 <em class="t-gray">How to use multi-factor authentication with gem CLI.</em>


### PR DESCRIPTION
* Removes link to old `http://docs.seattlerb.org/rubygems/` site from navigation bar.
* Add missing link to https://guides.rubygems.org/rubygems-org-compact-index-api/ to navigation bar.
* Corrects order by moving "Credits" to the end.
* Fixes some wrong "previous" links.
* Adds some missing "next" and "previous" links.
* Updates gem versions since I could not start jekyll locally otherwise with Ruby 3.3 and that fixes it.