### PR TITLE
Update v2 versions example payload.

### DIFF
--- a/rubygems-org-api-v2.md
+++ b/rubygems-org-api-v2.md
@@ -20,18 +20,48 @@ To return the version for a specific platform (e.g. "ruby", "java", "x86_64-linu
     $ curl https://rubygems.org/api/v2/rubygems/coulda/versions/0.7.1.json
 
     {
-      "authors":"Evan David Light",
-      "built_at":"2011-08-08T04:00:00.000Z",
-      "created_at":"2011-08-08T21:23:40.254Z",
-      "description":"Behaviour Driven Development derived from Cucumber but as an internal DSL with methods for reuse",
-      "downloads_count":2469,
-      "metadata":{},
-      "number":"0.7.1",
-      "summary":"Test::Unit-based acceptance testing DSL",
-      "platform":"ruby",
-      "ruby_version":null,
-      "prerelease":false,
-      "licenses":null,
-      "requirements":null,
-      "sha":"777c3a7ed83e44198b0a624976ec99822eb6f4a44bf1513eafbc7c13997cd86c"
+      "name": "coulda",
+      "downloads": 86573,
+      "version": "0.7.1",
+      "version_created_at": "2011-08-08T21:23:40.254Z",
+      "version_downloads": 5754,
+      "platform": "ruby",
+      "authors": "Evan David Light",
+      "info": "Behaviour Driven Development derived from Cucumber but as an internal DSL with methods for reuse",
+      "licenses": null,
+      "metadata": {
+        "homepage_uri": "http://coulda.tiggerpalace.com"
+      },
+      "yanked": false,
+      "sha": "777c3a7ed83e44198b0a624976ec99822eb6f4a44bf1513eafbc7c13997cd86c",
+      "spec_sha": "57b863cff56029a0085eaf1b3416b701ed4fa75418d062358b45753e270c9ffa",
+      "project_uri": "https://rubygems.org/gems/coulda",
+      "gem_uri": "https://rubygems.org/gems/coulda-0.7.1.gem",
+      "homepage_uri": "http://coulda.tiggerpalace.com",
+      "wiki_uri": null,
+      "documentation_uri": null,
+      "mailing_list_uri": null,
+      "source_code_uri": null,
+      "bug_tracker_uri": null,
+      "changelog_uri": null,
+      "funding_uri": null,
+      "dependencies": {
+        "development": [],
+        "runtime": [
+          {
+            "name": "yourdsl",
+            "requirements": "~> 0.7"
+          }
+        ]
+      },
+      "built_at": "2011-08-08T04:00:00.000Z",
+      "created_at": "2011-08-08T21:23:40.254Z",
+      "description": "Behaviour Driven Development derived from Cucumber but as an internal DSL with methods for reuse",
+      "downloads_count": 5754,
+      "number": "0.7.1",
+      "summary": "Test::Unit-based acceptance testing DSL",
+      "rubygems_version": ">= 0",
+      "ruby_version": null,
+      "prerelease": false,
+      "requirements": null
     }


### PR DESCRIPTION
:information_source: during https://github.com/rubygems/rubygems.org/pull/4742 I have found out example payload is out of sync.