### PR TITLE
Show aliases in specification reference

### DIFF
--- a/rdoc/generator/template/jekdoc/classpage.rhtml
+++ b/rdoc/generator/template/jekdoc/classpage.rhtml
@@ -67,6 +67,9 @@ next: /command-reference
    description.gsub! %r%<a\shref=(["'])Specification\.html\1>Specification</a>%,
                      'Specification' %>
 <%= description %>
+<% if method.aliases.any? -%>
+Also known as: **<%= method.aliases.map(&:name).join(", ") %>**
+<% end -%>
 <% end -%>
 <% end -%>
 

--- a/specification-reference.md
+++ b/specification-reference.md
@@ -347,6 +347,7 @@ next: /command-reference
 
 <pre class="ruby"><span class="ruby-identifier">spec</span>.<span class="ruby-identifier">add_runtime_dependency</span> <span class="ruby-string">&#39;example&#39;</span>, <span class="ruby-string">&#39;~&gt; 1.1&#39;</span>, <span class="ruby-string">&#39;&gt;= 1.1.4&#39;</span>
 </pre>
+Also known as: **add_dependency**
 
 <a id="author="> </a>
 


### PR DESCRIPTION
Fixes https://github.com/rubygems/rubygems/issues/7790.

### Problem

`add_dependency` is not documented in the [specification reference](https://guides.rubygems.org/specification-reference/), but it is documented in the [rubydoc documentation](https://www.rubydoc.info/github/rubygems/rubygems/Gem/Specification#add_runtime_dependency-instance_method). Since the specification is generated from the `Gem::Specification` class, similarly to rubydoc, I think the specification should also mention `add_dependency` as an alias.

### Solution

Change the documentation template to show aliases in the specification reference like so:

<img width="715" alt="02o9x" src="https://github.com/rubygems/guides/assets/236461/eb518156-0f41-45fb-b4cd-94f340295d91">

FYI there is currently only one alias, which is `add_dependency`.

### Alternative solution

I mentioned in https://github.com/rubygems/rubygems/issues/7790 that `add_dependency` seems to be more prominent, so alternatively we could show it more prominently in the reference by making it have its own entry as done in my other branch [here](https://github.com/jeromedalbert/guides/blob/show-aliases/rdoc/generator/template/jekdoc/classpage.rhtml#L31), where the end result would look [like this](http://i.jeromedalbert.com/k2uqq.png). I can update the PR if this way is preferred.