### PR TITLE
Add missing comma to metadata example

### DIFF
--- a/specification-reference.md
+++ b/specification-reference.md
@@ -286,7 +286,7 @@ next: /command-reference
   &quot;homepage_uri&quot;      =&gt; &quot;https://bestgemever.example.io&quot;,
   &quot;mailing_list_uri&quot;  =&gt; &quot;https://groups.example.com/bestgemever&quot;,
   &quot;source_code_uri&quot;   =&gt; &quot;https://example.com/user/bestgemever&quot;,
-  &quot;wiki_uri&quot;          =&gt; &quot;https://example.com/user/bestgemever/wiki&quot;
+  &quot;wiki_uri&quot;          =&gt; &quot;https://example.com/user/bestgemever/wiki&quot;,
   &quot;funding_uri&quot;       =&gt; &quot;https://example.com/donate&quot;
 }</pre>
 


### PR DESCRIPTION
I tried copying and pasting this example of gemspec metadata into a gem and noticed that it had a syntax error because there's a missing comma.

From this page: https://guides.rubygems.org/specification-reference/



![CleanShot 2024-10-20 at 14 07 56@2x](https://github.com/user-attachments/assets/2041af10-afb7-436c-98bf-441f8c887db4)
