### PR TITLE
 Remove ui only documentation

### DIFF
--- a/api-key-scopes.md
+++ b/api-key-scopes.md
@@ -103,7 +103,7 @@ If you are using a key to modify only one of your gems, please consider gem scop
 Enable MFA on specific API keys
 -----------------------------
 
-If your account has MFA enabled on the **UI only** or **UI and gem signin** [authentication level](https://guides.rubygems.org/setting-up-multifactor-authentication/#authentication-levels), you have the option to enable MFA on a specific API key. This will require an OTP code for `gem push`, `yank`, `owner --add/--remove` commands.
+If your account has MFA enabled on the **UI and gem signin** [authentication level](https://guides.rubygems.org/setting-up-multifactor-authentication/#authentication-levels), you have the option to enable MFA on a specific API key. This will require an OTP code for `gem push`, `yank`, `owner --add/--remove` commands.
 
 You can toggle this option when creating or editing an API key on the UI.
 ![New API key with MFA enabled](/images/new-mfa-api-key.png){:class="t-img"}

--- a/setting-up-multifactor-authentication.md
+++ b/setting-up-multifactor-authentication.md
@@ -23,13 +23,14 @@ When you register a new device or enable MFA for the first time, we will enable
 MFA for both the UI and the API. If you go to the "Edit Settings" page again, in the "Multi-factor Authentication" section, you
 will see a dropdown menu with these options:
 
-- **UI only (Deprecated)**: sign in from browser, updating MFA levels and resetting password will require OTP code. These are referred to as UI operations.
 - **UI and gem signin**: UI operations and `gem signin` will require OTP code.
 - **UI and API**: UI operations, `gem signin`, `push`, `owner --add` and `owner --remove` will require OTP code.
 
-Note: If you are on the "UI only" or "UI and gem signin" authentication level,
+UI Only was previously a valid MFA level, however, it is being removed and only accounts that are at that level will still see it in the dropdown.
+
+Note: If you are on the **UI and gem signin** authentication level,
 you can selectively enable MFA on specific API keys (see [API key scopes](https://guides.rubygems.org/api-key-scopes/#enable-mfa-on-specific-api-keys)).
-This is different from the "UI and API" level as MFA is enabled on all API keys by default and cannot be selectively enabled.
+This is different from the **UI and API** level as MFA is enabled on all API keys by default and cannot be selectively enabled.
 
 Steps to change your MFA level:
 

--- a/setting-up-multifactor-authentication.md
+++ b/setting-up-multifactor-authentication.md
@@ -26,7 +26,7 @@ will see a dropdown menu with these options:
 - **UI and gem signin**: UI operations and `gem signin` will require OTP code.
 - **UI and API**: UI operations, `gem signin`, `push`, `owner --add` and `owner --remove` will require OTP code.
 
-UI Only was previously a valid MFA level, however, it has been removed and only accounts that were previously at that level will still see it in the dropdown.
+**UI only** was previously a valid MFA level. However, it has been removed, and only accounts that are currently at that level will still see it in the dropdown.
 
 Note: If you are on the **UI and gem signin** authentication level,
 you can selectively enable MFA on specific API keys (see [API key scopes](https://guides.rubygems.org/api-key-scopes/#enable-mfa-on-specific-api-keys)).

--- a/setting-up-multifactor-authentication.md
+++ b/setting-up-multifactor-authentication.md
@@ -26,7 +26,7 @@ will see a dropdown menu with these options:
 - **UI and gem signin**: UI operations and `gem signin` will require OTP code.
 - **UI and API**: UI operations, `gem signin`, `push`, `owner --add` and `owner --remove` will require OTP code.
 
-UI Only was previously a valid MFA level, however, it is being removed and only accounts that are at that level will still see it in the dropdown.
+UI Only was previously a valid MFA level, however, it has been removed and only accounts that were previously at that level will still see it in the dropdown.
 
 Note: If you are on the **UI and gem signin** authentication level,
 you can selectively enable MFA on specific API keys (see [API key scopes](https://guides.rubygems.org/api-key-scopes/#enable-mfa-on-specific-api-keys)).


### PR DESCRIPTION
Replaces #311. Rebased off main so it can be merged.

Here's @kevinlinxc's original description from #311:

> Since the removal of ui only was merged (https://github.com/rubygems/rubygems.org/pull/3084), the guides should be updated. 
>
> I remove other mentions of it and only talk about it in the place where dropdown is mentioned, explaining that it will still show up for people that have it as their set MFA level. Perhaps this bit is unnecessary but it feels like harmless transparency.
>
> Another idea that I think we should do is link the ui only removal blog post.