### PR TITLE
Consistently use `persist-credentials: false` for actions/checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,14 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.4.2
         with:
           path: guides
+          persist-credentials: false
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.4.2 
         with:
           repository: rubygems/rubygems
           path: rubygems
           ref: 3.6
+          persist-credentials: false
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@a2bbe5b1b236842c1cb7dd11e8e3b51e0a616acc #v1.202.0

--- a/trusted-publishing/releasing-gems.md
+++ b/trusted-publishing/releasing-gems.md
@@ -25,6 +25,8 @@ jobs:
     steps:
       # Set up
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
The default value for `persist-credentials` is `true`. While an issue exists to change the default, there's not a strong signal that the default will change. Given this, consistently setting `persist-credentials` to `false` whenever possible is prudent.