### PR TITLE
Removed old/dead pickaxe link for writing C extensions.

### DIFF
--- a/gems-with-extensions.md
+++ b/gems-with-extensions.md
@@ -274,10 +274,6 @@ Further Reading
 * Interfaces to C libraries can be written using ruby and
   [fiddle](https://docs.ruby-lang.org/en/master/Fiddle.html) (part
   of the standard library) or [ruby-ffi](https://github.com/ffi/ffi)
-* [Extending Ruby](https://ruby-doc.com/docs/ProgrammingRuby/html/ext_ruby.html)
-  is a [Programming Ruby](http://docs.ruby-doc.com/docs/ProgrammingRuby/)
-  book chapter about building C extensions. _Please note_: this content is somewhat
-  older and some C extension APIs have changed.
 
 [extension.rdoc]: https://github.com/ruby/ruby/blob/master/doc/extension.rdoc
 [mkmf.rb]: https://github.com/ruby/ruby/blob/master/lib/mkmf.rb


### PR DESCRIPTION
ruby-doc.com died a couple months ago and the 1st edition pickaxe is
ancient. There's better writeups on writing C extensions elsewhere.
This is better to remove rather than finding another published
pickaxe.
