### PR TITLE
Introduce RubyGems/Bundler 4 upgrading guide

### DIFF
--- a/upgrading-to-bundler-4.md
+++ b/upgrading-to-bundler-4.md
@@ -1,6 +1,6 @@
 # Upgrading to Bundler 4
 
-We introduce breaking changes in Bundler 4 in order to improve usability, security, and maintainability of the tool. This document describes the changes that you will find when upgrading to Bundler 4, and how to prepare for them while still using Bundler 2.7.
+We introduced breaking changes in Bundler 4 in order to improve usability, security, and maintainability of the tool. This document describes the changes that you will find when upgrading to Bundler 4, and how to prepare for them while still using Bundler 2.7.
 
 ## Bundler 4 simulation mode
 
@@ -12,29 +12,31 @@ In order to prepare for Bundler 4, you can easily configure Bundler 2.7 to behav
 
 From now on in this document we will assume that all three of these configuration options are available, but will only mention `bundle config set <option> <value>`.
 
-The following is a summary of the changes that we plan to introduce in Bundler 4, and why we will be making those changes. Some of them should be well known already by existing users, because we have been printing deprecation messages for years, but some of them are defaults that will be switched in Bundler 4 and needs some heads up.
+The following is a summary of the changes that we introduced in Bundler 4, and why we made those changes. Some of them should be well known already by existing users, because we have been printing deprecation messages for years, but some of them are defaults that were switched in Bundler 4.
 
 ## CLI behavior changes
 
-### Running just `bundle` is not recommended to mean `bundle install` anymore
+### Running just `bundle` to mean `bundle install` is not recommended anymore
 
-We have a plan to change this default to make Bundler more friendly for new users. We do understand that long time users already know how Bundler works and find useful that just `bundle` defaults to `bundle install`.
+We changed this default to make Bundler more friendly for new users. We do understand that long time users already know how Bundler works and found it useful that just `bundle` defaulted to `bundle install`.
 
-Those users can keep the existing default by configuring:
+Currently, Bundler uses `install_or_cli_help` by default for backward compatibility. This automatically uses `bundle install` or shows help depending on the context.
+
+If you want to keep the current behavior (defaulting to `bundle install`), you can explicitly configure:
 
 ```sh
 bundle config set default_cli_command install_or_cli_help --global
 ```
 
-However, new users will benefit from a more explicit behavior where running:
+However, if you want to adopt the new behavior immediately where `bundle` only shows help, you can configure:
 
 ```sh
 bundle config set default_cli_command cli_help --global
 ```
 
-Please use this opportunity to use `bundle install` explicitly in your scripts and documentation, so that everyone is clear about what is going to happen.
+Please use `bundle install` explicitly in your scripts and documentation, so that everyone is clear about what is happening.
 
-### Flags passed to `bundle install` that relied on being remembered across invocations will be removed
+### Flags passed to `bundle install` that relied on being remembered across invocations have been removed
 
 In particular, the `--clean`, `--deployment`, `--frozen`, `--no-prune`, `--path`, `--shebang`, `--system`, `--without`, and `--with` options to `bundle install`.
 
@@ -42,23 +44,23 @@ Remembering CLI options has been a source of historical confusion and bug report
 
 A CLI tool should not behave differently across exactly the same invocations _unless_ explicitly configured to do so. This is what configuration is about after all, and things should never be silently configured without the user knowing about it.
 
-The problem with changing this behavior is that very common workflows are relying on it. For example, when you run `bundle install --without development:test` in production, those flags are persisted in the app's configuration file and further `bundle` invocations will happily ignore development and test gems.
+The problem with this behavior was that very common workflows were relying on it. For example, when you ran `bundle install --without development:test` in production, those flags were persisted in the app's configuration file and further `bundle` invocations would happily ignore development and test gems.
 
-This magic will disappear from bundler 4, and you will explicitly need to configure it, either through environment variables, application configuration, or machine configuration. For example, with `bundle config set --local without development test`.
+This magic has been removed from Bundler 4, and you now explicitly need to configure it, either through environment variables, application configuration, or machine configuration. For example, with `bundle config set --local without development test`.
 
-### `bundle viz` will be removed and extracted to a plugin.
+### `bundle viz` has been removed and extracted to a plugin.
 
-This is the only bundler command requiring external dependencies, both an OS dependency (the `graphviz` package) and a gem dependency (the `ruby-graphviz` gem). Removing these dependencies will make development easier and it was also seen by the bundler team as an opportunity to develop a bundler plugin that it's officially maintained by the RubyGems team, and that users can take as a reference to develop their own plugins.
+This was the only bundler command requiring external dependencies, both an OS dependency (the `graphviz` package) and a gem dependency (the `ruby-graphviz` gem). Removing these dependencies made development easier and it was also seen by the bundler team as an opportunity to develop a bundler plugin that is officially maintained by the RubyGems team, and that users can take as a reference to develop their own plugins.
 
-The new plugin will be called `bundler-graph` and it is available at https://github.com/rubygems/bundler-grap now.
+The new plugin is called `bundler-graph` and it is available at https://github.com/rubygems/bundler-grap now.
 
-The plugin will contain the same code as the old core command, the only difference being that the command is now implemented as `bundle graph` which is much easier to understand. However, the details of the plugin are under discussion. See [#3333](https://github.com/ruby/rubygems/issues/3333).
+The plugin contains the same code as the old core command, the only difference being that the command is now implemented as `bundle graph` which is much easier to understand.
 
-### The `bundle install` command will no longer accept a `--binstubs` flag.
+### The `bundle install` command no longer accepts a `--binstubs` flag.
 
 The `--binstubs` option has been removed from `bundle install` and replaced with the `bundle binstubs` command.
 
-The `--binstubs` flag would create binstubs for all executables present inside the gems in the project. This was hardly useful since most users will only use a subset of all the binstubs available to them. Also, it would force the introduction of a bunch of most likely unused files into source control. Because of this, binstubs now must be created and checked into version control individually.
+The `--binstubs` flag would create binstubs for all executables present inside the gems in the project. This was hardly useful since most users only use a subset of all the binstubs available to them. Also, it would force the introduction of a bunch of most likely unused files into source control. Because of this, binstubs now must be created and checked into version control individually.
 
 If you still want to create binstubs for all gems, you can run:
 
@@ -66,7 +68,7 @@ If you still want to create binstubs for all gems, you can run:
 bundle binstubs --all
 ```
 
-### The `bundle inject` command will be replaced with `bundle add`
+### The `bundle inject` command has been replaced with `bundle add`
 
 We believe the new command fits the user's mental model better and it supports a wider set of use cases.
 
@@ -74,17 +76,17 @@ The interface supported by `bundle inject` works exactly the same in `bundle add
 
 ## Gemfile and lockfile behavior changes
 
-### Bundler will include checksums in new lockfiles by default
+### Bundler includes checksums in new lockfiles by default
 
-We shipped this security feature recently and we believe it's time to turn it on by default, so that everyone benefits from the extra security assurances. So whenever you create a new lockfile, Bundler will include a CHECKSUMS section.
+We shipped this security feature and turned it on by default, so that everyone benefits from the extra security assurances. So whenever you create a new lockfile, Bundler now includes a CHECKSUMS section.
 
 Bundler will not automatically add a CHECKSUMS section to existing lockfiles, though, unless explicitly requested through `bundle lock --add-checksums`.
 
 ### Strict source pinning in Gemfile is enforced by default
 
-In bundler 4, the source for every dependency will be unambiguously defined, and Bundler will refuse to run otherwise.
+In Bundler 4, the source for every dependency is now unambiguously defined, and Bundler refuses to run otherwise.
 
-#### Multiple global Gemfile sources will no longer be supported.
+#### Multiple global Gemfile sources are no longer supported.
 
 Instead of something like this:
 
@@ -108,7 +110,7 @@ source "https://another_source" do
 end
 ```
 
-#### Global `path` and `git` sources will no longer be supported.
+#### Global `path` and `git` sources are no longer supported.
 
 Instead of something like this:
 
@@ -143,31 +145,31 @@ git "https://my_git_repo_with_gems" do
 end
 ```
 
-## Runtime behavior changes
+## Cache behavior changes
 
-### Git and Path gems will be included in `vendor/cache` by default
+### Git and Path gems are included in `vendor/cache` by default
 
-If you have a `vendor/cache` directory (to support offline scenarios, for example), Bundler will start including gems from `path` and `git` sources in there.
+If you have a `vendor/cache` directory (to support offline scenarios, for example), Bundler now includes gems from `path` and `git` sources in there.
 
 We're unsure why these gems were treated specially so we'll start caching them normally.
 
-### Bundler will use cached local data if available when network issues are found during resolution
+### Bundler uses cached local data if available when network issues are found during resolution
 
 Just trying to provide a more resilient behavior here.
 
 ## API behavior changes
 
-### `Bundler.clean_env`, `Bundler.with_clean_env`, `Bundler.clean_system`, and `Bundler.clean_exec` will be removed
+### `Bundler.clean_env`, `Bundler.with_clean_env`, `Bundler.clean_system`, and `Bundler.clean_exec` have been removed
 
-All of these helpers ultimately use `Bundler.clean_env` under the hood, which makes sure all bundler-related environment are removed inside the block it yields.
+All of these helpers ultimately used `Bundler.clean_env` under the hood, which made sure all bundler-related environment variables were removed inside the block it yields.
 
-After quite a lot user reports, we noticed that users don't usually want this but instead want the bundler environment as it was before the current process was started. Thus, `Bundler.with_original_env`, `Bundler.original_system`, and `Bundler.original_exec` were born. They all use the new `Bundler.original_env` under the hood.
+After quite a lot of user reports, we noticed that users don't usually want this but instead want the bundler environment as it was before the current process was started. Thus, `Bundler.with_original_env`, `Bundler.original_system`, and `Bundler.original_exec` were born. They all use the new `Bundler.original_env` under the hood.
 
-There's however some specific cases where the good old `Bundler.clean_env` behavior can be useful. For example, when testing Rails generators, you really want an environment where `bundler` is out of the picture. This is why we decided to keep the old behavior under a new more clear name, because we figured the word "clean" was too ambiguous. So we have introduced `Bundler.unbundled_env`, `Bundler.with_unbundled_env`, `Bundler.unbundled_system`, and `Bundler.unbundled_exec`.
+There are however some specific cases where the good old `Bundler.clean_env` behavior can be useful. For example, when testing Rails generators, you really want an environment where `bundler` is out of the picture. This is why we decided to keep the old behavior under a new more clear name, because we figured the word "clean" was too ambiguous. So we introduced `Bundler.unbundled_env`, `Bundler.with_unbundled_env`, `Bundler.unbundled_system`, and `Bundler.unbundled_exec`.
 
-### `Bundler.environment` is deprecated in favor of `Bundler.load`.
+### `Bundler.environment` has been deprecated in favor of `Bundler.load`.
 
-We're not sure how people might be using this directly but we have removed the `Bundler::Environment` class which was instantiated by `Bundler.environment` since we realized the `Bundler::Runtime` class was the same thing. During the transition `Bundler.environment` will delegate to `Bundler.load`, which holds the reference to the `Bundler::Environment`.
+We're not sure how people might be using this directly but we removed the `Bundler::Environment` class which was instantiated by `Bundler.environment` since we realized the `Bundler::Runtime` class was the same thing. `Bundler.environment` now delegates to `Bundler.load`, which holds the reference to the `Bundler::Runtime`.
 
 ### Removed public methods of `Bundler::SpecSet`
 
@@ -190,8 +192,8 @@ Please use `Bundler.rubygems.installed_specs` instead.
 
 ## Other notable changes
 
-### Deployment helpers for `vlad` and `capistrano` are being removed.
+### Deployment helpers for `vlad` and `capistrano` have been removed.
 
-These are natural deprecations since the `vlad` tool has had no activity for years whereas `capistrano` 3 has built-in Bundler integration in the form of the `capistrano-bundler` gem, and everyone using Capistrano 3 should be already using that instead. If for some reason, you are still using Capistrano 2, feel free to copy the Capistrano tasks out of the Bundler 2 file `lib/bundler/deployment.rb` and put them into your app.
+These were natural deprecations since the `vlad` tool has had no activity for years whereas `capistrano` 3 has built-in Bundler integration in the form of the `capistrano-bundler` gem, and everyone using Capistrano 3 should already be using that instead. If for some reason, you are still using Capistrano 2, feel free to copy the Capistrano tasks out of the Bundler 2 file `lib/bundler/deployment.rb` and put them into your app.
 
-In general, we don't want to maintain integrations for every deployment system out there, so that's why we are removing these.
+In general, we don't want to maintain integrations for every deployment system out there, so that's why we removed these.


### PR DESCRIPTION
I would like to publish "Upgrading guide to Bundler 4" based on [UPGRADING.md](https://github.com/ruby/rubygems/blob/749b498822f4ce61cd694ce852e8b5afa4d9e47e/doc/bundler/UPGRADING.md).

This document will be published with RubyGems/Bundler 4 stable releases.