### PR TITLE
Suppress rubygems_version warning

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -69,7 +69,6 @@ file 'command-reference.md' =>
   require 'rubygems/command_manager'
   require 'rdoc/erbio'
 
-  rubygems_version = Gem.rubygems_version.version
   names    = Gem::CommandManager.instance.command_names
   commands = {}
   names.each do |name|

--- a/command-reference.erb
+++ b/command-reference.erb
@@ -8,7 +8,7 @@ next: /rubygems-org-api
 
 <em class="t-gray">What each `gem` command does, and how to use it.</em>
 
-This reference was automatically generated from RubyGems version <%= rubygems_version %>.
+This reference was automatically generated from RubyGems version <%= Gem.rubygems_version.version %>.
 
 <%- commands.each do |name, command| -%><%= "* [gem #{name}](#gem-#{name})\n" %><%- end -%>
 <%- commands.each do |name, command| -%>


### PR DESCRIPTION
Removed the following:
```
/Users/hsbt/Documents/github.com/rubygems/guides.rubygems.org/Rakefile:72: warning: assigned but unused variable - rubygems_version
```