### PR TITLE
Add trailing slashes to `redirect_from` paths

### DIFF
--- a/dependency_management.md
+++ b/dependency_management.md
@@ -5,8 +5,8 @@ url: /dependency_management
 previous: /groups
 next: /rubygems_tls_ssl_troubleshooting_guide
 redirect_from:
-  - /bundler_sharing
-  - /rationale
+  - /bundler_sharing/
+  - /rationale/
 ---
 
 ## How to manage dependencies with Bundler

--- a/faqs.md
+++ b/faqs.md
@@ -4,7 +4,7 @@ title: Frequently Asked Questions
 url: /faqs
 previous: /contributing
 next: /plugins
-redirect_from: /faq
+redirect_from: /faq/
 ---
 
 <em class="t-gray">More of the "why" and "wtf" than "how".</em>

--- a/gems-with-extensions.md
+++ b/gems-with-extensions.md
@@ -4,7 +4,7 @@ title: Gems with Extensions
 url: /gems-with-extensions
 previous: /make-your-own-gem
 next: /name-your-gem
-redirect_from: /c-extensions
+redirect_from: /c-extensions/
 ---
 
 <em class="t-gray">Creating a gem that includes an extension that is built at install time.</em>

--- a/make-your-own-gem.md
+++ b/make-your-own-gem.md
@@ -2,7 +2,7 @@
 layout: default
 title: Make your own gem
 url: /make-your-own-gem/
-redirect_from: /creating_gem
+redirect_from: /creating_gem/
 previous: /what-is-a-gem/
 next: /gems-with-extensions/
 ---

--- a/trusted-publishing.md
+++ b/trusted-publishing.md
@@ -5,9 +5,9 @@ url: /trusted-publishing
 previous: /cve
 next: /organizations
 redirect_from:
-  - /trusted-publishing/adding-a-publisher
-  - /trusted-publishing/pushing-a-new-gem
-  - /trusted-publishing/releasing-gems
+  - /trusted-publishing/adding-a-publisher/
+  - /trusted-publishing/pushing-a-new-gem/
+  - /trusted-publishing/releasing-gems/
 ---
 
 With Trusted Publishing, releasing a new version of your gem is as simple as pushing a git tag to GitHub. There are no API tokens to create, rotate, or store as secrets — GitHub Actions securely authenticates with RubyGems.org on your behalf using short-lived tokens.

--- a/using-mfa-in-command-line.md
+++ b/using-mfa-in-command-line.md
@@ -5,8 +5,8 @@ url: /using-mfa-in-command-line
 previous: /setting-up-otp-mfa
 next: /mfa-requirement-opt-in
 redirect_from:
-  - /using-webauthn-mfa-in-command-line
-  - /using-otp-mfa-in-command-line
+  - /using-webauthn-mfa-in-command-line/
+  - /using-otp-mfa-in-command-line/
 ---
 <em class="t-gray">How to use multi-factor authentication with gem CLI.</em>
 


### PR DESCRIPTION
This fixes an issue where accessing the old links, such as https://guides.rubygems.org/creating_gem/ and https://guides.rubygems.org/faq/, still results in 404. The reason is that `redirect_from` only generates /creating_gem.html, does not generate /creating_gem/index.html.

It also seems that alias_generator.rb, which was removed in #453, used to generate /foo/index.html when given `alias: /foo`.

When I previously contributed #453, I tested it with `jekyll serve` only instead of running build. Because `jekyll serve` responds with /creating_gem.html even when accessing /creating_gem/, I did not catch this issue at the time.