### PR TITLE
Migrate github pages build from legacy builder

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUBY_VERSION=3.4.4
+ARG RUBY_VERSION=4.0.5
 FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION
 
 ENV BINDING="0.0.0.0"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name: RubyGems Guides",
+  "name": "RubyGems Guides",
   "dockerFile": "Dockerfile",
   "forwardPorts": [
     4000

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+---
+name: deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@12fd324f1d0b43274fdc8130f6980590a667c455 # v1.312.0
+        with:
+          ruby-version: 4.0
+          bundler-cache: true
+
+      - name: Build jekyll
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
+
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,8 +1,0 @@
-image: gitpod/workspace-ruby-3.1
-tasks:
-  - init: |
-      # Code fetch for generating command guide into /workspace/rubygems
-      git clone --depth 1 -b 3.3 https://github.com/rubygems/rubygems.git ../rubygems
-      bundle config set path vendor/bundle
-      bundle install
-    command: bundle exec jekyll serve

--- a/_config.yml
+++ b/_config.yml
@@ -1,12 +1,10 @@
 ---
+url: "https://guides.rubygems.org"
 exclude:
 - README.md
 - CNAME
 - vendor
 permalink: "pretty"
 plugins:
-- jekyll-redirect-from
-safe: true
-whitelist:
 - jekyll-redirect-from
 markdown: kramdown


### PR DESCRIPTION
This repository currently deploys `guides.rubygems.org` with the legacy GitHub Pages builder, which builds with the github-pages gem (Jekyll 3.x) and only runs allowlisted plugins.

#470 adds `jekyll-tailwindcss`, which the legacy builder cannot run, so it would ship an unstyled site.

This PR adds a deploy workflow that builds with the repository's own Gemfile (Jekyll 4) and deploys via `actions/deploy-pages`, following the existing convention of SHA-pinned actions.
