### PR TITLE
Add Bundler compatibility guide

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -141,6 +141,7 @@
 
           <h3 class="font-bold tracking-[0.04em] text-lg text-neutral-600 pt-4 pb-2">Bundler</h3>
           <ul>
+            <li><a class="sidenav-link" data-sidenav href="/bundler-compatibility">Bundler compatibility with Ruby</a></li>
             <li><a class="sidenav-link" data-sidenav href="/rubygems">Bundler in gems</a></li>
             <li><a class="sidenav-link" data-sidenav href="/gemfile">Gemfiles</a></li>
             <li><a class="sidenav-link" data-sidenav href="/getting_started">Getting Started</a></li>

--- a/bundler-compatibility.md
+++ b/bundler-compatibility.md
@@ -18,7 +18,11 @@ downgrading RubyGems should not affect Bundler.
 
 That effectively comes down to the following:
 
-* Bundler **2.6** or higher
+* Bundler **4.0** or higher
+  * requires a minimum ruby version of **3.2.0**, and a minimum RubyGems version of **3.4.1** (version of RubyGems shipped with ruby **3.2.0**).
+* Bundler **2.7**
+  * requires a minimum ruby version of **3.2.0**, and a minimum RubyGems version of **3.4.1** (version of RubyGems shipped with ruby **3.2.0**).
+* Bundler **2.6**
   * requires a minimum ruby version of **3.1.0**, and a minimum RubyGems version of **3.3.3** (version of RubyGems shipped with ruby **3.1.0**).
 * Bundler **2.5**
   * requires a minimum ruby version of **3.0.0**, and a minimum RubyGems version of **3.2.3** (version of RubyGems shipped with ruby **3.0.0**).

--- a/bundler-compatibility.md
+++ b/bundler-compatibility.md
@@ -1,0 +1,30 @@
+---
+layout: default
+title: Bundler compatibility with Ruby
+description: Ruby and RubyGems requirements needed for Bundler compatibility
+url: /bundler-compatibility
+previous: /credits
+next: /rubygems
+---
+## Bundler compatibility with Ruby & RubyGems
+
+The latest Bundler release should always support, at the very least, all
+rubies that have not yet reached their End of Life date.
+
+The latest Bundler release should always support all RubyGems versions higher
+than or equal to the one shipped with the oldest Ruby version supported.
+RubyGems is not allowed to be downgraded further than that, so upgrading or
+downgrading RubyGems should not affect Bundler.
+
+That effectively comes down to the following:
+
+* Bundler **2.6** or higher
+  * requires a minimum ruby version of **3.1.0**, and a minimum RubyGems version of **3.3.3** (version of RubyGems shipped with ruby **3.1.0**).
+* Bundler **2.5**
+  * requires a minimum ruby version of **3.0.0**, and a minimum RubyGems version of **3.2.3** (version of RubyGems shipped with ruby **3.0.0**).
+* Bundler **2.4**
+  * requires a minimum ruby version of **2.6.0**, and a minimum RubyGems version of **3.0.1** (version of RubyGems shipped with ruby **2.6.0**).
+* Bundler **2.0** through **2.3**
+  * requires a minimum ruby version of **2.3.0**, and a minimum RubyGems version of **2.5** (version of RubyGems shipped with ruby **2.3.0**).
+* Bundler **1**
+  * requires a minimum Ruby version of **1.8.7**, and a minimum RubyGems version of **1.3.6** (version of RubyGems shipped with ruby **1.8.7**).

--- a/credits.md
+++ b/credits.md
@@ -2,7 +2,7 @@
 layout: default
 title: Credits
 previous: /organizations/transferring-gems
-next: /rubygems
+next: /bundler-compatibility
 ---
 
 <em class="text-neutral-600">This site is [open source](https://github.com/rubygems/guides) and its content is

--- a/rubygems.md
+++ b/rubygems.md
@@ -2,7 +2,7 @@
 layout: default
 title: Bundler in gems
 url: /rubygems
-previous: /credits
+previous: /bundler-compatibility
 next: /gemfile
 ---
 


### PR DESCRIPTION
This ports https://bundler.io/compatibility.html to guides.rubygems.org as part of winding down bundler-site and consolidating its content here. The page lists the minimum Ruby and RubyGems versions required by each Bundler release series, now including rows for Bundler 2.7 and 4.0, both of which require Ruby 3.2.0 and RubyGems 3.4.1 per their gemspecs. The new URL is `/bundler-compatibility`, and bundler-site will redirect `/compatibility.html` there in a follow-up. The page is also added to the Bundler section of the sidebar and to the previous/next navigation chain.
