### PR TITLE
Move Bundler Command Reference to the Bundler sidebar section

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -108,7 +108,6 @@
             <li><a class="sidenav-link" data-sidenav href="/patterns">Patterns</a></li>
             <li><a class="sidenav-link" data-sidenav href="/specification-reference">Specification Reference</a></li>
             <li><a class="sidenav-link" data-sidenav href="/command-reference">Command Reference</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/command-reference/bundle">Bundler Command Reference</a></li>
             <li><a class="sidenav-link" data-sidenav href="/rubygems-org-api">RubyGems.org API</a></li>
             <li><a class="sidenav-link" data-sidenav href="/rubygems-org-api-v2">RubyGems.org API V2.0</a></li>
             <li><a class="sidenav-link" data-sidenav href="/rubygems-org-compact-index-api">RubyGems.org Compact Index API</a></li>
@@ -142,6 +141,7 @@
 
           <h3 class="font-bold tracking-[0.04em] text-lg text-neutral-600 pt-4 pb-2">Bundler</h3>
           <ul>
+            <li><a class="sidenav-link" data-sidenav href="/command-reference/bundle">Bundler Command Reference</a></li>
             <li><a class="sidenav-link" data-sidenav href="/bundler-compatibility">Bundler compatibility with Ruby</a></li>
             <li><a class="sidenav-link" data-sidenav href="/rubygems">Bundler in gems</a></li>
             <li><a class="sidenav-link" data-sidenav href="/gemfile">Gemfiles</a></li>


### PR DESCRIPTION
The sidebar listed Bundler Command Reference in the RubyGems section next to Command Reference, while every `bundle` command page belongs to the Bundler docs. This moves the link into the Bundler section, placed first to keep the section's alphabetical order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
