### PR TITLE
Regenerate bundler command reference

### DIFF
--- a/command-reference/bundle.html
+++ b/command-reference/bundle.html
@@ -85,6 +85,14 @@ started, and <a class="man-ref" href="/gemfile/">Gemfile<span class="s">(5)</spa
 and available to Bundler</dd>
 <dt><a href="/command-reference/bundle-show/"><code>bundle show(1)</code></a></dt>
 <dd>Show the source location of a particular gem in the bundle</dd>
+<dt><a href="/command-reference/bundle-info/"><code>bundle info(1)</code></a></dt>
+<dd>Show information for the given gem in your bundle</dd>
+<dt><a href="/command-reference/bundle-list/"><code>bundle list(1)</code></a></dt>
+<dd>List all the gems in the bundle</dd>
+<dt><a href="/command-reference/bundle-licenses/"><code>bundle licenses(1)</code></a></dt>
+<dd>Print the license of all gems in the bundle</dd>
+<dt><a href="/command-reference/bundle-fund/"><code>bundle fund(1)</code></a></dt>
+<dd>Lists information about gems seeking funding assistance</dd>
 <dt><a href="/command-reference/bundle-outdated/"><code>bundle outdated(1)</code></a></dt>
 <dd>Show all of the outdated gems in the current bundle</dd>
 <dt>
@@ -102,8 +110,14 @@ and available to Bundler</dd>
 <dd>Display platform compatibility information</dd>
 <dt><a href="/command-reference/bundle-clean/"><code>bundle clean(1)</code></a></dt>
 <dd>Clean up unused gems in your Bundler directory</dd>
+<dt><a href="/command-reference/bundle-pristine/"><code>bundle pristine(1)</code></a></dt>
+<dd>Restores installed gems to their pristine condition</dd>
 <dt><a href="/command-reference/bundle-doctor/"><code>bundle doctor(1)</code></a></dt>
 <dd>Display warnings about common problems</dd>
+<dt><a href="/command-reference/bundle-env/"><code>bundle env(1)</code></a></dt>
+<dd>Print information about the environment Bundler is running under</dd>
+<dt><a href="/command-reference/bundle-issue/"><code>bundle issue(1)</code></a></dt>
+<dd>Get help reporting Bundler issues</dd>
 <dt><a href="/command-reference/bundle-remove/"><code>bundle remove(1)</code></a></dt>
 <dd>Removes gems from the Gemfile</dd>
 <dt><a href="/command-reference/bundle-plugin/"><code>bundle plugin(1)</code></a></dt>


### PR DESCRIPTION
The UTILITIES section of `bundle.1.ronn` now lists `bundle-env`, `bundle-fund`, `bundle-info`, `bundle-issue`, `bundle-licenses`, `bundle-list` and `bundle-pristine` (ruby/rubygems commit 9e37b2fd9f), but the index page at `/command-reference/bundle` was generated before that change, so those pages were unreachable from it. This regenerates the index with `rake bundler_reference` against the Bundler 4.0.17 man pages plus that single upstream change, keeping the diff limited to the seven new links.

Generated with [Claude Code](https://claude.com/claude-code)
