### PR TITLE
Reorganize guides by task instead of by tool

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -178,7 +178,7 @@ task :bundler_reference => %w[RUBYGEMS_DIR_exists] do
     pages[slug] = { title: title, whatis: whatis, content: content.to_html.strip }
   end
 
-  chain = ['/command-reference'] + slugs.map { |slug| url_for.call(slug) } + ['/getting_started']
+  chain = ['/command-reference'] + slugs.map { |slug| url_for.call(slug) } + ['/gemfile_ruby']
 
   slugs.each_with_index do |slug, index|
     page = pages[slug]

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -94,26 +94,37 @@
       <div class="flow-root">
 
         <div class="md:float-left md:w-[240px] mb-[60px] md:mb-0 print:hidden">
+          <h3 class="font-bold tracking-[0.04em] text-lg text-neutral-600 pb-2">Getting Started</h3>
           <ul>
             <li><a class="sidenav-link" data-sidenav href="/rubygems-basics">RubyGems Basics</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/what-is-a-gem">What is a gem?</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/getting_started">Getting Started with Bundler</a></li>
             <li><a class="sidenav-link" data-sidenav href="/make-your-own-gem">Make your own gem</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/gems-with-extensions">Gems with Extensions</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/name-your-gem">Name your gem</a></li>
             <li><a class="sidenav-link" data-sidenav href="/publishing">Publishing your gem</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/security">Security Practices</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/managing-owners-using-ui">Managing owners using UI</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/removing-a-published-gem">Removing a Published gem</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/ssl-certificate-update">SSL Certificate Update</a></li>
+          </ul>
+
+          <h3 class="font-bold tracking-[0.04em] text-lg text-neutral-600 pt-5 pb-1">Guides</h3>
+          <h4 class="font-semibold tracking-[0.08em] uppercase text-xs text-neutral-500 pt-2 pb-1">Dependency Management</h4>
+          <ul>
+            <li><a class="sidenav-link" data-sidenav href="/using_bundler_in_applications">How to manage application dependencies with Bundler</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/dependency_management">How to manage dependencies with Bundler</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/updating_gems">How to update gems with Bundler</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/groups">How to manage groups of gems</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/git">How to install gems from git repositories</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/bundler_workflow">Recommended Workflow with Version Control</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/bundler_setup">How to use Bundler with Ruby</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/bundler_in_a_single_file_ruby_script">How to use Bundler in a single-file Ruby script</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/deploying">How to deploy bundled applications</a></li>
+          </ul>
+          <h4 class="font-semibold tracking-[0.08em] uppercase text-xs text-neutral-500 pt-3 pb-1">Gem Development</h4>
+          <ul>
+            <li><a class="sidenav-link" data-sidenav href="/name-your-gem">Name your gem</a></li>
             <li><a class="sidenav-link" data-sidenav href="/patterns">Patterns</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/specification-reference">Specification Reference</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/command-reference">Command Reference</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/rubygems-org-api">RubyGems.org API</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/rubygems-org-api-v2">RubyGems.org API V2.0</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/rubygems-org-compact-index-api">RubyGems.org Compact Index API</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/rubygems-org-rate-limits">RubyGems.org rate limits</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/api-key-scopes">API key scopes</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/run-your-own-gem-server">Run your own gem server</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/gems-with-extensions">Gems with Extensions</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/rubygems">Bundler in gems</a></li>
+          </ul>
+          <h4 class="font-semibold tracking-[0.08em] uppercase text-xs text-neutral-500 pt-3 pb-1">Publishing &amp; Security</h4>
+          <ul>
+            <li><a class="sidenav-link" data-sidenav href="/trusted-publishing">Trusted Publishing</a></li>
             <li><a class="sidenav-link" data-sidenav href="/setting-up-multifactor-authentication">Setting up multi-factor authentication</a></li>
             <ul class="pl-[8%]">
               <li><a class="sidenav-link--sub" data-sidenav href="/setting-up-webauthn-mfa">Setting up WebAuthn MFA</a></li>
@@ -121,14 +132,7 @@
             </ul>
             <li><a class="sidenav-link" data-sidenav href="/using-mfa-in-command-line">Using multi-factor authentication in command line</a></li>
             <li><a class="sidenav-link" data-sidenav href="/mfa-requirement-opt-in">MFA requirement opt in</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/using-s3-source">Using S3 as gem source</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/default-gems-and-bundled-gems">Default gems and bundled gems</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/resources">Resources</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/contributing">Contributing to RubyGems</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/faqs">Frequently Asked Questions</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/plugins">Plugins</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/cve">Common Vulnerabilities and Exposures</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/trusted-publishing">Trusted Publishing</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/managing-owners-using-ui">Managing owners using UI</a></li>
             <li><a class="sidenav-link" data-sidenav href="/organizations">Organizations</a></li>
             <ul class="pl-[8%]">
               <li><a class="sidenav-link--sub" data-sidenav href="/organizations/getting-started">Getting Started</a></li>
@@ -136,35 +140,63 @@
               <li><a class="sidenav-link--sub" data-sidenav href="/organizations/roles-and-permissions">Roles &amp; Permissions</a></li>
               <li><a class="sidenav-link--sub" data-sidenav href="/organizations/transferring-gems">Transferring Gems</a></li>
             </ul>
-            <li><a class="sidenav-link" data-sidenav href="/credits">Credits</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/removing-a-published-gem">Removing a Published gem</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/security">Security Practices</a></li>
+          </ul>
+          <h4 class="font-semibold tracking-[0.08em] uppercase text-xs text-neutral-500 pt-3 pb-1">Integrations</h4>
+          <ul>
+            <li><a class="sidenav-link" data-sidenav href="/rails">How to use Bundler with Rails</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/sinatra">How to use Bundler with Sinatra</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/bundler_docker_guide">How to use Bundler with Docker</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/rubymotion">How to use Bundler with RubyMotion</a></li>
+          </ul>
+          <h4 class="font-semibold tracking-[0.08em] uppercase text-xs text-neutral-500 pt-3 pb-1">Hosting &amp; Sources</h4>
+          <ul>
+            <li><a class="sidenav-link" data-sidenav href="/run-your-own-gem-server">Run your own gem server</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/using-s3-source">Using S3 as gem source</a></li>
+          </ul>
+          <h4 class="font-semibold tracking-[0.08em] uppercase text-xs text-neutral-500 pt-3 pb-1">Extending</h4>
+          <ul>
+            <li><a class="sidenav-link" data-sidenav href="/plugins">RubyGems Plugins</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/bundler_plugins">How to write a Bundler plugin</a></li>
+          </ul>
+          <h4 class="font-semibold tracking-[0.08em] uppercase text-xs text-neutral-500 pt-3 pb-1">Troubleshooting</h4>
+          <ul>
+            <li><a class="sidenav-link" data-sidenav href="/rubygems_tls_ssl_troubleshooting_guide">How to troubleshoot RubyGems and Bundler TLS/SSL Issues</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/ssl-certificate-update">SSL Certificate Update</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/git_bisect">How to use git bisect with Bundler</a></li>
           </ul>
 
-          <h3 class="font-bold tracking-[0.04em] text-lg text-neutral-600 pt-4 pb-2">Bundler</h3>
+          <h3 class="font-bold tracking-[0.04em] text-lg text-neutral-600 pt-5 pb-2">Concepts</h3>
           <ul>
+            <li><a class="sidenav-link" data-sidenav href="/what-is-a-gem">What is a gem?</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/default-gems-and-bundled-gems">Default gems and bundled gems</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/cve">Common Vulnerabilities and Exposures</a></li>
+          </ul>
+
+          <h3 class="font-bold tracking-[0.04em] text-lg text-neutral-600 pt-5 pb-2">Reference</h3>
+          <ul>
+            <li><a class="sidenav-link" data-sidenav href="/command-reference">gem Command Reference</a></li>
             <li><a class="sidenav-link" data-sidenav href="/command-reference/bundle">Bundler Command Reference</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/bundler-compatibility">Bundler compatibility with Ruby</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/rubygems">Bundler in gems</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/gemfile">Gemfiles</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/getting_started">Getting Started</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/bundler_2_upgrade">How to Upgrade to Bundler 2</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/deploying">How to deploy bundled applications</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/git">How to install gems from git repositories</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/using_bundler_in_applications">How to manage application dependencies with Bundler</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/groups">How to manage groups of gems</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/dependency_management">How to manage dependencies with Bundler</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/rubygems_tls_ssl_troubleshooting_guide">How to troubleshoot RubyGems and Bundler TLS/SSL Issues</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/updating_gems">How to update gems with Bundler</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/bundler_in_a_single_file_ruby_script">How to use Bundler in a single-file Ruby script</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/bundler_docker_guide">How to use Bundler with Docker</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/rails">How to use Bundler with Rails</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/bundler_setup">How to use Bundler with Ruby</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/rubymotion">How to use Bundler with RubyMotion</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/sinatra">How to use Bundler with Sinatra</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/git_bisect">How to use git bisect with Bundler</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/bundler_plugins">How to write a Bundler plugin</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/bundler_known_plugins">Known Plugins</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/bundler_workflow">Recommended Workflow with Version Control</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/gemfile">Gemfile Reference</a></li>
             <li><a class="sidenav-link" data-sidenav href="/gemfile_ruby">Ruby Directive</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/specification-reference">Specification Reference</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/rubygems-org-api">RubyGems.org API</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/rubygems-org-api-v2">RubyGems.org API V2.0</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/rubygems-org-compact-index-api">RubyGems.org Compact Index API</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/rubygems-org-rate-limits">RubyGems.org rate limits</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/api-key-scopes">API key scopes</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/bundler-compatibility">Bundler compatibility with Ruby</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/bundler_known_plugins">Known Bundler Plugins</a></li>
+          </ul>
+
+          <h3 class="font-bold tracking-[0.04em] text-lg text-neutral-600 pt-5 pb-2">Appendix</h3>
+          <ul>
+            <li><a class="sidenav-link" data-sidenav href="/faqs">Frequently Asked Questions</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/resources">Resources</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/contributing">Contributing to RubyGems</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/bundler_2_upgrade">How to Upgrade to Bundler 2</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/credits">Credits</a></li>
           </ul>
         </div>
 

--- a/api-key-scopes.md
+++ b/api-key-scopes.md
@@ -2,7 +2,7 @@
 layout: default
 title: API key scopes
 previous: /rubygems-org-rate-limits
-next: /run-your-own-gem-server
+next: /bundler-compatibility
 ---
 
 <em class="text-neutral-600">RubyGems.org API keys, their scopes, and CLI usage</em>

--- a/bundler-compatibility.md
+++ b/bundler-compatibility.md
@@ -3,8 +3,8 @@ layout: default
 title: Bundler compatibility with Ruby
 description: Ruby and RubyGems requirements needed for Bundler compatibility
 url: /bundler-compatibility
-previous: /credits
-next: /rubygems
+previous: /api-key-scopes
+next: /bundler_known_plugins
 ---
 ## Bundler compatibility with Ruby & RubyGems
 

--- a/bundler_2_upgrade.md
+++ b/bundler_2_upgrade.md
@@ -2,8 +2,8 @@
 layout: default
 title: How to Upgrade to Bundler 2
 url: /bundler_2_upgrade
-previous: /getting_started
-next: /deploying
+previous: /contributing
+next: /credits
 ---
 
 So! You’ve heard that [Bundler 2 was released](https://bundler.io/blog/2019/01/03/announcing-bundler-2.html)! If you want to try out Bundler 2 for yourself, this guide will help you do that.

--- a/bundler_docker_guide.md
+++ b/bundler_docker_guide.md
@@ -2,8 +2,8 @@
 layout: default
 title: How to use Bundler with Docker
 url: /bundler_docker_guide
-previous: /bundler_in_a_single_file_ruby_script
-next: /rails
+previous: /sinatra
+next: /rubymotion
 ---
 
 ## Introduction

--- a/bundler_in_a_single_file_ruby_script.md
+++ b/bundler_in_a_single_file_ruby_script.md
@@ -2,8 +2,8 @@
 layout: default
 title: How to use Bundler in a single-file Ruby script
 url: /bundler_in_a_single_file_ruby_script
-previous: /updating_gems
-next: /bundler_docker_guide
+previous: /bundler_setup
+next: /deploying
 ---
 
 To use Bundler in a single-file script, add `require 'bundler/inline'` at the top of your Ruby file. Then, use the `gemfile` method to declare any gem sources and gems that you need. Here's an example:

--- a/bundler_known_plugins.md
+++ b/bundler_known_plugins.md
@@ -2,8 +2,8 @@
 layout: default
 title: Known Plugins
 url: /bundler_known_plugins
-previous: /bundler_plugins
-next: /bundler_workflow
+previous: /bundler-compatibility
+next: /faqs
 ---
 
 {% for plugin in site.data.known_plugins %}

--- a/bundler_plugins.md
+++ b/bundler_plugins.md
@@ -2,8 +2,8 @@
 layout: default
 title: How to write a Bundler plugin
 url: /bundler_plugins
-previous: /git_bisect
-next: /bundler_known_plugins
+previous: /plugins
+next: /rubygems_tls_ssl_troubleshooting_guide
 ---
 
 <a name="how-to-write-a-bundler-plugin"></a>

--- a/bundler_setup.md
+++ b/bundler_setup.md
@@ -2,8 +2,8 @@
 layout: default
 title: How to use Bundler with Ruby
 url: /bundler_setup
-previous: /rails
-next: /rubymotion
+previous: /bundler_workflow
+next: /bundler_in_a_single_file_ruby_script
 ---
 Configure the load path so all dependencies in
 your Gemfile can be required

--- a/bundler_workflow.md
+++ b/bundler_workflow.md
@@ -2,8 +2,8 @@
 layout: default
 title: Recommended Workflow with Version Control
 url: /bundler_workflow
-previous: /bundler_known_plugins
-next: /gemfile_ruby
+previous: /git
+next: /bundler_setup
 ---
 
 In general, when working with an application managed with bundler, you

--- a/command-reference.erb
+++ b/command-reference.erb
@@ -2,8 +2,8 @@
 layout: default
 title: Command Reference
 url: /command-reference
-previous: /specification-reference
-next: /rubygems-org-api
+previous: /cve
+next: /command-reference/bundle
 ---
 
 <em class="text-neutral-600">What each `gem` command does, and how to use it.</em>

--- a/command-reference.md
+++ b/command-reference.md
@@ -2,8 +2,8 @@
 layout: default
 title: Command Reference
 url: /command-reference
-previous: /specification-reference
-next: /rubygems-org-api
+previous: /cve
+next: /command-reference/bundle
 ---
 
 <em class="text-neutral-600">What each `gem` command does, and how to use it.</em>

--- a/command-reference/gemfile.html
+++ b/command-reference/gemfile.html
@@ -5,7 +5,7 @@ description: "A format for describing gem dependencies for Ruby programs"
 url: /gemfile
 permalink: /gemfile/
 previous: /command-reference/bundle-version
-next: /getting_started
+next: /gemfile_ruby
 ---
 
 <em class="text-neutral-600">A format for describing gem dependencies for Ruby programs</em>

--- a/contributing.md
+++ b/contributing.md
@@ -3,7 +3,7 @@ layout: default
 title: Contributing to RubyGems
 url: /contributing
 previous: /resources
-next: /faqs
+next: /bundler_2_upgrade
 ---
 
 <em class="text-neutral-600">How you can help make RubyGems and the surrounding ecosystem better.</em>

--- a/credits.md
+++ b/credits.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title: Credits
-previous: /organizations/transferring-gems
-next: /bundler-compatibility
+previous: /bundler_2_upgrade
+next: /
 ---
 
 <em class="text-neutral-600">This site is [open source](https://github.com/rubygems/guides) and its content is

--- a/cve.md
+++ b/cve.md
@@ -2,8 +2,8 @@
 layout: default
 title: RubyGems Common Vulnerabilities and Exposures
 url: /cve
-previous: /credits
-next: /trusted-publishing
+previous: /default-gems-and-bundled-gems
+next: /command-reference
 ---
 
 ## CVE-2013-4287: Algorithmic complexity vulnerability in RubyGems 2.0.7 and older

--- a/default-gems-and-bundled-gems.md
+++ b/default-gems-and-bundled-gems.md
@@ -2,8 +2,8 @@
 layout: default
 title: Default Gems and Bundled Gems
 url: /default-gems-and-bundled-gems
-previous: /using-s3-source
-next: /resources
+previous: /what-is-a-gem
+next: /cve
 ---
 
 <em class="text-neutral-600">Understanding Ruby's standard library gems.</em>

--- a/dependency_management.md
+++ b/dependency_management.md
@@ -2,8 +2,8 @@
 layout: default
 title: How to manage dependencies with Bundler
 url: /dependency_management
-previous: /groups
-next: /rubygems_tls_ssl_troubleshooting_guide
+previous: /using_bundler_in_applications
+next: /updating_gems
 redirect_from:
   - /bundler_sharing/
   - /rationale/

--- a/deploying.md
+++ b/deploying.md
@@ -2,8 +2,8 @@
 layout: default
 title: How to deploy bundled applications
 url: /deploying
-previous: /bundler_2_upgrade
-next: /git
+previous: /bundler_in_a_single_file_ruby_script
+next: /name-your-gem
 ---
 
 Before deploying an app that uses Bundler, add your `Gemfile`

--- a/faqs.md
+++ b/faqs.md
@@ -2,8 +2,8 @@
 layout: default
 title: Frequently Asked Questions
 url: /faqs
-previous: /contributing
-next: /plugins
+previous: /bundler_known_plugins
+next: /resources
 redirect_from: /faq/
 ---
 

--- a/gemfile_ruby.md
+++ b/gemfile_ruby.md
@@ -2,8 +2,8 @@
 layout: default
 title: Ruby Directive
 url: /gemfile_ruby
-previous: /bundler_workflow
-next: /
+previous: /gemfile
+next: /specification-reference
 ---
 
 ## Specifying a Ruby Version

--- a/gems-with-extensions.md
+++ b/gems-with-extensions.md
@@ -2,8 +2,8 @@
 layout: default
 title: Gems with Extensions
 url: /gems-with-extensions
-previous: /make-your-own-gem
-next: /name-your-gem
+previous: /patterns
+next: /rubygems
 redirect_from: /c-extensions/
 ---
 

--- a/getting_started.md
+++ b/getting_started.md
@@ -2,8 +2,8 @@
 layout: default
 title: Getting Started
 url: /getting_started
-previous: /gemfile
-next: /bundler_2_upgrade
+previous: /rubygems-basics
+next: /make-your-own-gem
 ---
 ## What is Bundler?
 

--- a/git.md
+++ b/git.md
@@ -2,8 +2,8 @@
 layout: default
 title: How to install gems from git repositories
 url: /git
-previous: /deploying
-next: /using_bundler_in_applications
+previous: /groups
+next: /bundler_workflow
 ---
 This document is written for Bundler 2.1 or higher.
 Use `bundle config X Y` instead of `bundle config set X Y`

--- a/git_bisect.md
+++ b/git_bisect.md
@@ -2,8 +2,8 @@
 layout: default
 title: How to use git bisect with Bundler
 url: /git_bisect
-previous: /sinatra
-next: /bundler_plugins
+previous: /ssl-certificate-update
+next: /what-is-a-gem
 ---
 
 ## How to use git bisect

--- a/groups.md
+++ b/groups.md
@@ -2,8 +2,8 @@
 layout: default
 title: How to manage groups of gems
 url: /groups
-previous: /using_bundler_in_applications
-next: /dependency_management
+previous: /updating_gems
+next: /git
 ---
 
 Grouping your dependencies allows you

--- a/index.md
+++ b/index.md
@@ -5,15 +5,58 @@ previous: /credits
 next: /rubygems-basics
 ---
 
-<em class="text-neutral-600">Learn how RubyGems works, and how to make your own.</em>
+<em class="text-neutral-600">Everything about library management in Ruby: learn what gems are, how to use them in your projects, and how to build and publish your own.</em>
 
-The RubyGems software allows you to easily 
-download, install, and use ruby software packages on your system.  The
-software package is called a "gem" which contains a packaged Ruby
-application or library.
+Ruby libraries are packaged and distributed as **gems**. Two tools that ship with Ruby manage them: **RubyGems** installs individual gems and provides the `gem` command, and **Bundler** tracks the exact set of gems an application depends on through a `Gemfile`. [RubyGems.org](https://rubygems.org) is the community hosting service where gems are published and downloaded.
 
-Gems can be used to extend or modify
-functionality in Ruby applications.  Commonly they're used to distribute
-reusable functionality that is shared with other Rubyists for use in
-their applications and libraries.  Some gems provide command line
-utilities to help automate tasks and speed up your work.
+```sh
+# Install a gem and use it right away
+gem install nokogiri
+
+# Track dependencies for a project
+bundle init
+bundle add rack
+```
+
+<div class="not-prose grid gap-5 sm:grid-cols-2 my-10">
+  <div class="rounded-xl border border-neutral-300 bg-white p-6">
+    <h2 class="text-xl font-bold text-neutral-800 mb-1">Getting Started</h2>
+    <p class="text-neutral-600 mb-4">New to gems? Follow the tutorial from installing your first gem to publishing your own.</p>
+    <ul class="space-y-1.5">
+      <li><a class="text-orange-700 hover:underline" href="/rubygems-basics">RubyGems Basics</a></li>
+      <li><a class="text-orange-700 hover:underline" href="/getting_started">Getting Started with Bundler</a></li>
+      <li><a class="text-orange-700 hover:underline" href="/make-your-own-gem">Make your own gem</a></li>
+      <li><a class="text-orange-700 hover:underline" href="/publishing">Publishing your gem</a></li>
+    </ul>
+  </div>
+  <div class="rounded-xl border border-neutral-300 bg-white p-6">
+    <h2 class="text-xl font-bold text-neutral-800 mb-1">Guides</h2>
+    <p class="text-neutral-600 mb-4">Task-oriented how-tos for everyday work with gems.</p>
+    <ul class="space-y-1.5">
+      <li><a class="text-orange-700 hover:underline" href="/updating_gems">Update gems with Bundler</a></li>
+      <li><a class="text-orange-700 hover:underline" href="/trusted-publishing">Set up Trusted Publishing</a></li>
+      <li><a class="text-orange-700 hover:underline" href="/setting-up-multifactor-authentication">Secure your account with MFA</a></li>
+      <li><a class="text-orange-700 hover:underline" href="/deploying">Deploy a bundled application</a></li>
+    </ul>
+  </div>
+  <div class="rounded-xl border border-neutral-300 bg-white p-6">
+    <h2 class="text-xl font-bold text-neutral-800 mb-1">Concepts</h2>
+    <p class="text-neutral-600 mb-4">How library management in Ruby works under the hood.</p>
+    <ul class="space-y-1.5">
+      <li><a class="text-orange-700 hover:underline" href="/what-is-a-gem">What is a gem?</a></li>
+      <li><a class="text-orange-700 hover:underline" href="/default-gems-and-bundled-gems">Default gems and bundled gems</a></li>
+      <li><a class="text-orange-700 hover:underline" href="/cve">Common Vulnerabilities and Exposures</a></li>
+    </ul>
+  </div>
+  <div class="rounded-xl border border-neutral-300 bg-white p-6">
+    <h2 class="text-xl font-bold text-neutral-800 mb-1">Reference</h2>
+    <p class="text-neutral-600 mb-4">Commands, file formats, and APIs in full detail.</p>
+    <ul class="space-y-1.5">
+      <li><a class="text-orange-700 hover:underline" href="/command-reference">gem Command Reference</a></li>
+      <li><a class="text-orange-700 hover:underline" href="/command-reference/bundle">Bundler Command Reference</a></li>
+      <li><a class="text-orange-700 hover:underline" href="/gemfile">Gemfile Reference</a></li>
+      <li><a class="text-orange-700 hover:underline" href="/specification-reference">Specification Reference</a></li>
+      <li><a class="text-orange-700 hover:underline" href="/rubygems-org-api">RubyGems.org API</a></li>
+    </ul>
+  </div>
+</div>

--- a/make-your-own-gem.md
+++ b/make-your-own-gem.md
@@ -3,8 +3,8 @@ layout: default
 title: Make your own gem
 url: /make-your-own-gem/
 redirect_from: /creating_gem/
-previous: /what-is-a-gem/
-next: /gems-with-extensions/
+previous: /getting_started
+next: /publishing
 ---
 
 <p><em class="text-neutral-600">From start to finish, learn how to package your Ruby code in a gem.</em></p>

--- a/managing-owners-using-ui.md
+++ b/managing-owners-using-ui.md
@@ -2,8 +2,8 @@
 layout: default
 title: Managing Owners via UI
 url: /managing-owners-using-ui
-previous: /security
-next: /removing-a-published-gem
+previous: /mfa-requirement-opt-in
+next: /organizations
 ---
 
 <em class="text-neutral-600">How to add or remove owners to your gem using the web UI?</em>

--- a/mfa-requirement-opt-in.md
+++ b/mfa-requirement-opt-in.md
@@ -3,7 +3,7 @@ layout: default
 title: MFA requirement opt-in
 url: /mfa-requirement-opt-in
 previous: /using-mfa-in-command-line
-next: /using-s3-source
+next: /managing-owners-using-ui
 ---
 <em class="text-neutral-600">How to opt-in for MFA requirement.</em>
 

--- a/name-your-gem.md
+++ b/name-your-gem.md
@@ -2,8 +2,8 @@
 layout: default
 title: Name your gem
 url: /name-your-gem
-previous: /gems-with-extensions
-next: /publishing
+previous: /deploying
+next: /patterns
 ---
 
 <em class="text-neutral-600">Our recommendation on the use of "_" and "-" in your gem's name.</em>

--- a/organizations.md
+++ b/organizations.md
@@ -2,7 +2,7 @@
 layout: default
 title: Organizations
 url: /organizations
-previous: /trusted-publishing
+previous: /managing-owners-using-ui
 next: /organizations/getting-started
 ---
 

--- a/organizations/transferring-gems.md
+++ b/organizations/transferring-gems.md
@@ -3,7 +3,7 @@ url: /organizations/transferring-gems
 title: Transferring Gems to Organizations
 layout: default
 previous: /organizations/roles-and-permissions
-next: /credits
+next: /removing-a-published-gem
 ---
 
 <div class="beta-banner">

--- a/patterns.md
+++ b/patterns.md
@@ -2,8 +2,8 @@
 layout: default
 title: Patterns
 url: /patterns
-previous: /ssl-certificate-update
-next: /specification-reference
+previous: /name-your-gem
+next: /gems-with-extensions
 ---
 
 <em class="text-neutral-600">Common practices to make your gem users' and other developers' lives easier.</em>

--- a/plugins.md
+++ b/plugins.md
@@ -2,8 +2,8 @@
 layout: default
 title: Plugins
 url: /plugins
-previous: /faqs
-next: /cve
+previous: /using-s3-source
+next: /bundler_plugins
 ---
 
 <em class="text-neutral-600">Extensions that use the RubyGems plugin API.</em>

--- a/publishing.md
+++ b/publishing.md
@@ -2,8 +2,8 @@
 layout: default
 title: Publishing your gem
 url: /publishing
-previous: /name-your-gem
-next: /security
+previous: /make-your-own-gem
+next: /using_bundler_in_applications
 ---
 
 <em class="text-neutral-600">Start with an idea, end with a distributable package of Ruby code.</em>

--- a/rails.md
+++ b/rails.md
@@ -2,8 +2,8 @@
 layout: default
 title: How to use Bundler with Rails
 url: /rails
-previous: /bundler_docker_guide
-next: /bundler_setup
+previous: /security
+next: /sinatra
 ---
 
 Rails comes with baked-in support for Bundler.

--- a/removing-a-published-gem.md
+++ b/removing-a-published-gem.md
@@ -2,8 +2,8 @@
 layout: default
 title: Removing a published gem
 url: /removing-a-published-gem
-previous: /managing-owners-using-ui
-next: /ssl-certificate-update
+previous: /organizations/transferring-gems
+next: /security
 ---
 
 <em class="text-neutral-600">Published a gem before it was ready for release? Published a gem with the wrong name?</em>

--- a/resources.md
+++ b/resources.md
@@ -2,7 +2,7 @@
 layout: default
 title: Resources
 url: /resources
-previous: /default-gems-and-bundled-gems
+previous: /faqs
 next: /contributing
 ---
 

--- a/rubygems-basics.md
+++ b/rubygems-basics.md
@@ -3,7 +3,7 @@ layout: default
 title: RubyGems Basics
 url: /rubygems-basics
 previous: /
-next: /what-is-a-gem
+next: /getting_started
 ---
 
 <em class="text-neutral-600">Use of common RubyGems commands</em>

--- a/rubygems-org-api.md
+++ b/rubygems-org-api.md
@@ -2,7 +2,7 @@
 layout: default
 title: RubyGems.org API
 url: /rubygems-org-api
-previous: /command-reference
+previous: /specification-reference
 next: /rubygems-org-api-v2
 ---
 

--- a/rubygems-org-rate-limits.md
+++ b/rubygems-org-rate-limits.md
@@ -2,7 +2,7 @@
 layout: default
 title: RubyGems.org rate limits
 url: /rubygems-org-rate-limits
-previous: /rubygems-org-api-v2
+previous: /rubygems-org-compact-index-api
 next: /api-key-scopes
 ---
 

--- a/rubygems.md
+++ b/rubygems.md
@@ -2,8 +2,8 @@
 layout: default
 title: Bundler in gems
 url: /rubygems
-previous: /bundler-compatibility
-next: /gemfile
+previous: /gems-with-extensions
+next: /trusted-publishing
 ---
 
 ## Using Bundler while developing a gem

--- a/rubygems_tls_ssl_troubleshooting_guide.md
+++ b/rubygems_tls_ssl_troubleshooting_guide.md
@@ -2,8 +2,8 @@
 layout: default
 title: How to troubleshoot RubyGems and Bundler TLS/SSL Issues
 url: /rubygems_tls_ssl_troubleshooting_guide
-previous: /dependency_management
-next: /updating_gems
+previous: /bundler_plugins
+next: /ssl-certificate-update
 ---
 
 If you’ve experienced issues related to SSL certificates and/or TLS versions, you’ve come

--- a/rubymotion.md
+++ b/rubymotion.md
@@ -2,8 +2,8 @@
 layout: default
 title: How to use Bundler with RubyMotion
 url: /rubymotion
-previous: /bundler_setup
-next: /sinatra
+previous: /bundler_docker_guide
+next: /run-your-own-gem-server
 ---
 
 If you don't have a RubyMotion app yet, generate one.

--- a/run-your-own-gem-server.md
+++ b/run-your-own-gem-server.md
@@ -2,8 +2,8 @@
 layout: default
 title: Run your own gem server
 url: /run-your-own-gem-server
-previous: /api-key-scopes
-next: /setting-up-multifactor-authentication
+previous: /rubymotion
+next: /using-s3-source
 ---
 
 <em class="text-neutral-600">Need to serve gems locally or for your organization?</em>

--- a/security.md
+++ b/security.md
@@ -2,8 +2,8 @@
 layout: default
 title: Security
 url: /security
-previous: /publishing
-next: /managing-owners-using-ui
+previous: /removing-a-published-gem
+next: /rails
 ---
 
 <em class="text-neutral-600">How to build and install cryptographically signed gems-- and other security concerns.</em>

--- a/setting-up-multifactor-authentication.md
+++ b/setting-up-multifactor-authentication.md
@@ -2,7 +2,7 @@
 layout: default
 title: Setting up multi-factor authentication
 url: /setting-up-multifactor-authentication
-previous: /run-your-own-gem-server
+previous: /trusted-publishing
 next: /setting-up-webauthn-mfa
 ---
 

--- a/sinatra.md
+++ b/sinatra.md
@@ -2,8 +2,8 @@
 layout: default
 title: How to use Bundler with Sinatra
 url: /sinatra
-previous: /rubymotion
-next: /git_bisect
+previous: /rails
+next: /bundler_docker_guide
 ---
 
 To use bundler with a Sinatra application, you only need to do two things. First, create a Gemfile.

--- a/specification-reference.md
+++ b/specification-reference.md
@@ -2,8 +2,8 @@
 layout: default
 title: Specification Reference
 url: /specification-reference
-previous: /patterns
-next: /command-reference
+previous: /gemfile_ruby
+next: /rubygems-org-api
 ---
 
 

--- a/ssl-certificate-update.md
+++ b/ssl-certificate-update.md
@@ -2,8 +2,8 @@
 layout: default
 title: SSL Certificate Update
 url: /ssl-certificate-update
-previous: /removing-a-published-gem
-next: /patterns
+previous: /rubygems_tls_ssl_troubleshooting_guide
+next: /git_bisect
 ---
 
 If you’ve seen the following SSL error when trying to pull updates from RubyGems:

--- a/trusted-publishing.md
+++ b/trusted-publishing.md
@@ -2,8 +2,8 @@
 layout: default
 title: Trusted Publishing
 url: /trusted-publishing
-previous: /cve
-next: /organizations
+previous: /rubygems
+next: /setting-up-multifactor-authentication
 redirect_from:
   - /trusted-publishing/adding-a-publisher/
   - /trusted-publishing/pushing-a-new-gem/

--- a/updating_gems.md
+++ b/updating_gems.md
@@ -2,8 +2,8 @@
 layout: default
 title: How to update gems with Bundler
 url: /updating_gems
-previous: /rubygems_tls_ssl_troubleshooting_guide
-next: /bundler_in_a_single_file_ruby_script
+previous: /dependency_management
+next: /groups
 ---
 ### Updating a Dependency
 <a name="updating-a-dependency"></a>

--- a/using-s3-source.md
+++ b/using-s3-source.md
@@ -2,8 +2,8 @@
 layout: default
 title: Using S3 as gem source
 url: /using-s3-source
-previous: /mfa-requirement-opt-in
-next: /default-gems-and-bundled-gems
+previous: /run-your-own-gem-server
+next: /plugins
 ---
 <em class="text-neutral-600">How to use S3 bucket as gem source.</em>
 

--- a/using_bundler_in_applications.md
+++ b/using_bundler_in_applications.md
@@ -2,8 +2,8 @@
 layout: default
 title: How to manage application dependencies with Bundler
 url: /using_bundler_in_applications
-previous: /git
-next: /groups
+previous: /publishing
+next: /dependency_management
 ---
 
 This guide was originally written for Bundler v1.12. If you are using a different version, keep in mind that the output can differ.

--- a/what-is-a-gem.md
+++ b/what-is-a-gem.md
@@ -2,8 +2,8 @@
 layout: default
 title: What is a gem?
 url: /what-is-a-gem/
-previous: /rubygems-basics/
-next: /make-your-own-gem/
+previous: /git_bisect
+next: /default-gems-and-bundled-gems
 ---
 
 <em class="text-neutral-600">Unpack the mystery behind what's in a RubyGem.</em>


### PR DESCRIPTION
The sidebar was two flat lists, one for RubyGems and one for Bundler, so readers had to know which tool a task belonged to before they could find a page. This reorganizes the same pages into Getting Started, Guides grouped by task, Concepts, Reference, and Appendix, following the structure of the uv and cargo documentation. No URLs change.

The top page now introduces how gems, RubyGems, Bundler, and RubyGems.org relate and links into each section. The `previous`/`next` reading chain follows the new order as one closed loop across all pages. The generated bundle man pages keep their internal order, with the chain endpoints updated in the `Rakefile` so regeneration stays consistent.
