### PR TITLE
Replace bundler.io links with guides-internal links

### DIFF
--- a/bundler_docker_guide.md
+++ b/bundler_docker_guide.md
@@ -12,7 +12,7 @@ The official Docker images for Ruby assume that you will use only one applicatio
 
 If you want to install more than one Gemfile in your container, or simply install gems via RubyGems and use them as system gems, this situation is confusing, and has historically led to many confusing errors that appear to be bugs in Bundler.
 
-However, these errors ultimately come from the way the Dockerfile tells Bundler to create [binstubs](https://bundler.io/v1.16/man/bundle-binstubs.1.html) (which are linked to one application and Gemfile) in a single global place for the entire container. If you install two Gemfiles with `rake`, for example, running the `rake` command will always load the last Gemfile that was installed, and never any others.
+However, these errors ultimately come from the way the Dockerfile tells Bundler to create [binstubs](/command-reference/bundle-binstubs/) (which are linked to one application and Gemfile) in a single global place for the entire container. If you install two Gemfiles with `rake`, for example, running the `rake` command will always load the last Gemfile that was installed, and never any others.
 
 ## Dockerfiles for multiple Ruby applications and gems
 

--- a/bundler_setup.md
+++ b/bundler_setup.md
@@ -29,7 +29,7 @@ require 'nokogiri'
 
 Ruby 2.0 and RubyGems 2.0 both require Bundler 1.3 or later. If you have questions about compatibility between Bundler and your system, please check the compatibility list.
 
-<a href="https://bundler.io/compatibility.html" class="btn btn-primary">Learn More: Compatibility</a>
+<a href="/bundler-compatibility" class="btn btn-primary">Learn More: Compatibility</a>
 
 ## Setting Up Your Application to Use Bundler
 <a name="setting-up-your-application-to-use-bundler"></a>

--- a/bundler_workflow.md
+++ b/bundler_workflow.md
@@ -221,4 +221,4 @@ $ bin/rspec spec/models
 The executables installed into `bin` are scoped to the
 bundle, and will always work.
 
-<a href="https://bundler.io/man/bundle-exec.1.html" class="btn btn-primary">Learn More: Executables</a>
+<a href="/command-reference/bundle-exec/" class="btn btn-primary">Learn More: Executables</a>

--- a/deploying.md
+++ b/deploying.md
@@ -30,7 +30,7 @@ with the exact same gems you use in development.
 If you have run `bundle package`, the cached
 gems will be used automatically.
 
-<a href="https://bundler.io/man/bundle-cache.1.html" class="btn btn-primary">Learn More: Packing</a>
+<a href="/command-reference/bundle-cache/" class="btn btn-primary">Learn More: Packing</a>
 
 ### After deploying
 
@@ -45,7 +45,7 @@ Alternatively, you can use the `--binstubs` option on the
 install command to generate executable binaries that can be used instead of
 `bundle exec`.
 
-<a href="https://bundler.io/man/bundle-exec.1.html" class="btn btn-primary">Learn More: Executables</a>
+<a href="/command-reference/bundle-exec/" class="btn btn-primary">Learn More: Executables</a>
 
 ### Heroku
 

--- a/gemfile_ruby.md
+++ b/gemfile_ruby.md
@@ -58,7 +58,7 @@ Using the `platform` command with the `--ruby` flag, you can see what `ruby` dir
 ruby 3.1.4p0 (jruby 9.4.10.0)
 ~~~
 
-<a href="https://bundler.io/man/bundle-platform.1.html" class="btn btn-primary">Learn More: bundle platform</a>
+<a href="/command-reference/bundle-platform/" class="btn btn-primary">Learn More: bundle platform</a>
 
 In the `ruby` directive, `:patchlevel` is optional, as patchlevel releases are usually compatible and include important security fixes.
 The patchlevel option checks the `RUBY_PATCHLEVEL` constant, and if not specified then bundler will simply ignore it.

--- a/getting_started.md
+++ b/getting_started.md
@@ -14,7 +14,7 @@ Bundler is an exit from dependency hell, and ensures that the gems
 you need are present in development, staging, and production.
 Starting work on a project is as simple as `bundle install`.
 
-<a href="https://bundler.io/whats_new.html" class="btn btn-primary">What's new in Bundler</a>
+<a href="https://github.com/ruby/rubygems/releases/latest" class="btn btn-primary">What's new in Bundler</a>
 <a href="/dependency_management" class="btn btn-primary">Managing dependencies</a>
 
 ## Getting Started
@@ -43,7 +43,7 @@ $ bundle install
 $ git add Gemfile Gemfile.lock
 ~~~
 
-<a href="https://bundler.io/man/bundle-install.1.html" class="btn btn-primary">Learn More: bundle install</a>
+<a href="/command-reference/bundle-install/" class="btn btn-primary">Learn More: bundle install</a>
 
 The second command adds the Gemfile and Gemfile.lock to your repository. This ensures
 that other developers on your app, as well as your deployment environment, will all use
@@ -84,7 +84,7 @@ $ bin/rspec spec/models
 The executables installed into `bin` are scoped to the
 bundle, and will always work.
 
-<a href="https://bundler.io/man/bundle-exec.1.html" class="btn btn-primary">Learn More: Executables</a>
+<a href="/command-reference/bundle-exec/" class="btn btn-primary">Learn More: Executables</a>
 
 ## Create a rubygem with Bundler
 <a name="create-gem"></a>
@@ -113,7 +113,7 @@ Creating gem 'my_gem'...
 Initializing git repo in ./my_gem
 ~~~
 
-<a href="https://bundler.io/man/bundle-gem.1.html" class="btn btn-primary">Learn More: bundle gem</a>
+<a href="/command-reference/bundle-gem/" class="btn btn-primary">Learn More: bundle gem</a>
 
 ## Use Bundler with
 <a name="use-bundler"></a>
@@ -132,11 +132,11 @@ or [mailing list](http://groups.google.com/group/ruby-bundler).
 If you're interested in contributing to the project (no programming skills needed),
 read [the contributing guide](/contributing)
 or [the development guide](https://github.com/ruby/rubygems/tree/master/doc#development).
-While participating in the Bundler project, please keep the [code of conduct](https://bundler.io/conduct.html)
+While participating in the Bundler project, please keep the [code of conduct](https://github.com/ruby/rubygems/blob/HEAD/CODE_OF_CONDUCT.md)
 in mind, and be inclusive and friendly towards everyone. If you have sponsorship or security questions, please contact the core team directly.
 
-<a href="https://bundler.io/conduct.html" class="btn btn-primary">Code of Conduct</a>
+<a href="https://github.com/ruby/rubygems/blob/HEAD/CODE_OF_CONDUCT.md" class="btn btn-primary">Code of Conduct</a>
 <a href="http://webchat.freenode.net/?channels=bundler" class="btn btn-primary">#bundler on IRC</a>
 <a href="http://groups.google.com/group/ruby-bundler" class="btn btn-primary">Mailing list</a>
 <a href="/contributing" class="btn btn-primary">Contributing</a>
-<a href="mailto:team@bundler.io" class="btn btn-primary">Email core team</a>
+<a href="https://github.com/ruby/rubygems/discussions" class="btn btn-primary">GitHub Discussions</a>

--- a/groups.md
+++ b/groups.md
@@ -122,7 +122,7 @@ these groups. You can see all of the settings that Bundler saved there
 by running `bundle config`, which will also print out global
 settings (stored in `~/.bundle/config`) and settings set via
 environment variables. For more information on configuring Bundler,
-please see: [`bundle config`](https://bundler.io/man/bundle-config.1.html)
+please see: [`bundle config`](/command-reference/bundle-config/)
 
 You can also specify which groups to automatically require through the parameters to
 `Bundler.require`. The `:default` group includes all gems not

--- a/patterns.md
+++ b/patterns.md
@@ -128,7 +128,7 @@ specific version of a gem:
     require "extlib"
 
 It's reasonable for applications that consume gems to use this (though they
-could also use a tool like [Bundler](https://bundler.io/)). Gems themselves
+could also use a tool like [Bundler](/getting_started)). Gems themselves
 **should not** do this. They should instead use dependencies in the gemspec so
 RubyGems can handle loading the dependency instead of the user.
 
@@ -220,7 +220,7 @@ specific bug fix you can use a compound requirement:
     gem 'library', '>= 2.2.1'
 
 > If you're dealing with a lot of gem dependencies in your application, we
-> recommend that you take a look into [Bundler](https://bundler.io/) or
+> recommend that you take a look into [Bundler](/getting_started) or
 > [Isolate](https://github.com/jbarnette/isolate) which do a great job of
 > managing a complex version manifest for many gems.
 

--- a/publishing.md
+++ b/publishing.md
@@ -33,7 +33,7 @@ The simplest way (from the author's perspective) to share a gem for other
 developers' use is to distribute it in source code form. If you place the full
 source code for your gem on a public git repository (often, though not always,
 this means sharing it via [GitHub](https://github.com)), then other users can
-install it with [Bundler's git functionality](https://bundler.io/v2.0/man/gemfile.5.html#GIT).
+install it with [Bundler's git functionality](/gemfile/#GIT).
 
 For example, you can install the latest code for the wicked_pdf gem in a
 project by including this line in your Gemfile:

--- a/run-your-own-gem-server.md
+++ b/run-your-own-gem-server.md
@@ -153,7 +153,7 @@ Then install gems as usual:
     Successfully installed secretgem-0.0.1
     1 gem installed
 
-If you're using [Bundler](https://bundler.io/) then you can specify this
+If you're using [Bundler](/getting_started) then you can specify this
 server as a gem source in your `Gemfile`:
 
     [~/dev/myapp] cat Gemfile

--- a/using_bundler_in_applications.md
+++ b/using_bundler_in_applications.md
@@ -86,7 +86,7 @@ Gems inside block will be retrieved from given source.
 
 ***
 
-Learn more about `source` [here](https://bundler.io/man/gemfile.5.html#GLOBAL-SOURCES). 
+Learn more about `source` [here](/gemfile/#GLOBAL-SOURCE). 
 
 ### Adding Gems
 
@@ -121,11 +121,11 @@ gem "nokogiri", ">= 1.4.2"
 
 ***
 
-Learn more about gems in Gemfile [here](https://bundler.io/man/gemfile.5.html#GEMS).
+Learn more about gems in Gemfile [here](/gemfile/#GEMS).
 
 ### Gemfile Syntax
 
-Learn more about Gemfile syntax from the [gemfile manpage](https://bundler.io/man/gemfile.5.html#SYNTAX).
+Learn more about Gemfile syntax from the [gemfile manpage](/gemfile/#SYNTAX).
 
 ## Installing Gems - **bundle install**
 
@@ -146,7 +146,7 @@ This should give you similar output:
     Bundle complete! 1 Gemfile dependency, 4 gems now installed.
     Use `bundle show [gemname]` to see where a bundled gem is installed.
 
-It should also create [`Gemfile.lock` file](https://bundler.io/man/bundle-install.1.html#THE-GEMFILE-LOCK):
+It should also create [`Gemfile.lock` file](/command-reference/bundle-install/#THE-GEMFILE-LOCK):
 
     GEM
       remote: https://rubygems.org/
@@ -171,7 +171,7 @@ This Gemfile.lock is described in [next chapter](#gemfilelock).
 ### Deployment
 
 For deployment you should use
-[`--deployment` option](https://bundler.io/man/bundle-install.1.html#DEPLOYMENT-MODE):
+[`--deployment` option](/command-reference/bundle-install/#DEPLOYMENT-MODE):
 
     $ bundle install --deployment
     
@@ -184,7 +184,7 @@ To run this command, there are some requirements:
 
 ***
 
-To learn more about `bundle install` command click [here](https://bundler.io/man/bundle-install.1.html).
+To learn more about `bundle install` command click [here](/command-reference/bundle-install/).
 
 ## Gemfile.lock
 
@@ -223,7 +223,7 @@ Let's break it down:
   * `remote` - source of gems
   * `specs` - installed gems (with versions). We can see here that `mini_portile2` is
   dependency of `nokogiri` because it's beneath and indented
-* `PLATFORMS` - platform that is used in your application ([see more here](https://bundler.io/man/gemfile.5.html#PLATFORMS)).
+* `PLATFORMS` - platform that is used in your application ([see more here](/gemfile/#PLATFORMS)).
 * `DEPENDENCIES` - gems defined in our Gemfile.
 * `BUNDLED WITH` - version of Bundler which was last used to change `Gemfile.lock`
 
@@ -240,7 +240,7 @@ making all gems in Gemfile available to `require` and use.
 
 ***
 
-To learn more about `bundle exec` command click [here](https://bundler.io/man/bundle-exec.1.html).
+To learn more about `bundle exec` command click [here](/command-reference/bundle-exec/).
 
 ## Updating Gems - **bundle outdated** and **bundle update**
 
@@ -281,9 +281,9 @@ To update specific gems, use `bundle update *gems`
 
 ***
 
-To learn more about `bundle outdated` command click [here](https://bundler.io/bundle_outdated.html).
+To learn more about `bundle outdated` command click [here](/command-reference/bundle-outdated/).
 
-To learn more about `bundle update` command click [here](https://bundler.io/man/bundle-update.1.html).
+To learn more about `bundle update` command click [here](/command-reference/bundle-update/).
 
 ## Recommended Workflow
 


### PR DESCRIPTION
bundler.io has been scaled down and its guide and man pages now redirect to guides.rubygems.org, so guides should link to its own pages directly instead of going through the redirect. This replaces all `bundler.io` links in 11 guide pages. Man page links go to `/command-reference/<cmd>/` following #493, `gemfile.5.html` links go to `/gemfile/` with anchors preserved, and `compatibility.html` goes to `/bundler-compatibility`. The `#GLOBAL-SOURCES` anchor does not exist on the generated page, so it now points at the existing `#GLOBAL-SOURCE` section. Links without a guides equivalent move to the `ruby/rubygems` repository. The code of conduct, `whats_new.html`, and the `team@bundler.io` mailto now point at `CODE_OF_CONDUCT.md`, the latest release, and GitHub Discussions. `ssl-certificate-update.md` and `bundler_2_upgrade.md` are left untouched because they will be removed in follow-up PRs.

Generated with [Claude Code](https://claude.com/claude-code)
