### PR TITLE
Add a standalone guide page for Bundler cooldown

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -176,6 +176,7 @@
             </ul>
             <li><a class="sidenav-link" data-sidenav href="/removing-a-published-gem">Removing a Published gem</a></li>
             <li><a class="sidenav-link" data-sidenav href="/security">Security Practices</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/cooldown">How to delay new gem versions with cooldown</a></li>
           </ul>
           <h4 class="font-semibold tracking-[0.08em] uppercase text-xs text-neutral-500 pt-3 pb-1">Integrations</h4>
           <ul>

--- a/cooldown.md
+++ b/cooldown.md
@@ -1,0 +1,45 @@
+---
+layout: default
+title: How to delay new gem versions with cooldown
+url: /cooldown
+previous: /security
+next: /rails
+---
+
+<em class="text-neutral-600">How to keep Bundler from resolving to gem versions published in the last few days.</em>
+
+Most malicious gem releases are detected and yanked within days of publication. A cooldown excludes gem versions newer than a given number of days from dependency resolution, so your application never installs a release before the ecosystem has had time to vet it.
+
+Enabling cooldown
+-----------------
+
+To enable a cooldown for every Bundler run in a project, set the number of days in Bundler's configuration:
+
+    bundle config set cooldown 7
+
+The setting can also come from the `BUNDLE_COOLDOWN` environment variable. For a single run, pass `--cooldown N` to `bundle install`, `bundle update`, or `bundle add`. Passing `--cooldown 0` disables cooldown for that run.
+
+`bundle outdated` also accepts `--cooldown N`. Instead of hiding versions still inside the window, it annotates them, appending "in cooldown for Nd more days" in the prose output and "(cooldown Nd)" in the Latest column of the table form.
+
+Per-source cooldown
+-------------------
+
+A cooldown can also be declared for an individual source in the Gemfile:
+
+    source "https://rubygems.org", cooldown: 7
+
+The effective cooldown for any given gem is resolved from three layers. The CLI flag takes precedence over the config setting, which takes precedence over the per-source value. The CLI flag and the config setting apply uniformly to every source, including sources declared with their own `cooldown:` value.
+
+To keep a trusted private gem server permanently exempt while still cooling down public gems, declare it with `cooldown: 0` in the Gemfile. Note that `--cooldown N` on the command line still overrides that exemption for the run.
+
+Trade-offs
+----------
+
+A cooldown delays every new version, including releases that fix security vulnerabilities. When you need an urgent fix before the window has elapsed, bypass the cooldown for that run with `bundle update <gem> --cooldown 0`, combined with `--conservative` to minimize changes to other gems.
+
+Server support
+--------------
+
+Cooldown filtering depends on the gem server providing a per-version `created_at` timestamp in the v2 compact-index format. Versions without that metadata are treated as outside the cooldown window and remain resolvable. That includes older gem servers, private registries that still emit the v1 format, and historical entries that predate the v2 cutover on rubygems.org. If you rely on cooldown for supply-chain protection, confirm that your gem server emits `created_at` in its `/info/<gem>` responses.
+
+For the full description of the setting, see the `cooldown` entry in [bundle config](/command-reference/bundle-config/).

--- a/rails.md
+++ b/rails.md
@@ -2,7 +2,7 @@
 layout: default
 title: How to use Bundler with Rails
 url: /rails
-previous: /security
+previous: /cooldown
 next: /sinatra
 ---
 

--- a/security.md
+++ b/security.md
@@ -3,7 +3,7 @@ layout: default
 title: Security
 url: /security
 previous: /removing-a-published-gem
-next: /rails
+next: /cooldown
 ---
 
 <em class="text-neutral-600">How to protect your account as a gem author, harden the gems you install, and report vulnerabilities.</em>
@@ -49,7 +49,7 @@ Most malicious releases are detected and yanked within days of publication. A co
 
     bundle config set cooldown 7
 
-You can also pass `--cooldown N` to `bundle install`, `bundle update`, `bundle add`, and `bundle outdated`, or set a per-source value in the Gemfile with `source "https://rubygems.org", cooldown: 7`. The CLI flag takes precedence over the config setting, which takes precedence over the per-source value. To exempt a trusted internal source, declare it with `cooldown: 0`. Cooldown relies on the gem server publishing a creation time for each version through the v2 compact index. Versions from servers that do not provide it are treated as outside the cooldown window. See the `cooldown` entry in [bundle config](/command-reference/bundle-config/) for details.
+You can also pass `--cooldown N` to `bundle install`, `bundle update`, `bundle add`, and `bundle outdated`, or set a per-source value in the Gemfile with `source "https://rubygems.org", cooldown: 7`. The CLI flag takes precedence over the config setting, which takes precedence over the per-source value. To exempt a trusted internal source, declare it with `cooldown: 0`. Cooldown relies on the gem server publishing a creation time for each version through the v2 compact index. Versions from servers that do not provide it are treated as outside the cooldown window. See [How to delay new gem versions with cooldown](/cooldown) for details.
 
 ### Pinning gem sources
 


### PR DESCRIPTION
Add a standalone guide page for Bundler's cooldown feature at `/cooldown`, placed after the security page in the sidebar and in the previous/next chain. It covers enabling cooldown through `bundle config` or `--cooldown`, per-source configuration in the Gemfile and the precedence between the three layers, the trade-off for urgent security fixes, and the dependency on the v2 compact-index `created_at` metadata. The content is sourced from the generated `bundle-config`, `bundle-install`, `bundle-update`, `bundle-add`, and `bundle-outdated` man pages. The cooldown section on the security page now links to the new guide.

Part of the guides restructuring plan.
