### PR TITLE
Add an Installation page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -130,6 +130,7 @@
           </div>
           <h3 class="font-bold tracking-[0.04em] text-lg text-neutral-600 pb-2">Getting Started</h3>
           <ul>
+            <li><a class="sidenav-link" data-sidenav href="/installation">Installation</a></li>
             <li><a class="sidenav-link" data-sidenav href="/rubygems-basics">RubyGems Basics</a></li>
             <li><a class="sidenav-link" data-sidenav href="/getting_started">Getting Started with Bundler</a></li>
             <li><a class="sidenav-link" data-sidenav href="/make-your-own-gem">Make your own gem</a></li>

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Guides
 previous: /credits
-next: /rubygems-basics
+next: /installation
 ---
 
 <em class="text-neutral-600">Everything about library management in Ruby: learn what gems are, how to use them in your projects, and how to build and publish your own.</em>
@@ -23,6 +23,7 @@ bundle add rack
     <h2 class="text-xl font-bold text-neutral-800 mb-1">Getting Started</h2>
     <p class="text-neutral-600 mb-4">New to gems? Follow the tutorial from installing your first gem to publishing your own.</p>
     <ul class="space-y-1.5">
+      <li><a class="text-orange-700 hover:underline" href="/installation">Installation</a></li>
       <li><a class="text-orange-700 hover:underline" href="/rubygems-basics">RubyGems Basics</a></li>
       <li><a class="text-orange-700 hover:underline" href="/getting_started">Getting Started with Bundler</a></li>
       <li><a class="text-orange-700 hover:underline" href="/make-your-own-gem">Make your own gem</a></li>

--- a/installation.md
+++ b/installation.md
@@ -1,0 +1,47 @@
+---
+layout: default
+title: Installation
+url: /installation
+previous: /
+next: /rubygems-basics
+---
+
+<em class="text-neutral-600">How to get RubyGems and Bundler and keep them up to date.</em>
+
+RubyGems and Bundler ship with Ruby, so installing Ruby gives you both tools. To check that they are available:
+
+    gem --version
+    bundle --version
+
+If you do not have Ruby yet, see the [official installation guide](https://www.ruby-lang.org/en/documentation/installation/) for the options available on your platform.
+
+Updating RubyGems
+-----------------
+
+Ruby comes with the RubyGems version that was current when that Ruby was released. To upgrade to the latest version:
+
+    gem update --system
+
+To upgrade to a specific version instead, pass the version number:
+
+    gem update --system <version>
+
+Both forms download the `rubygems-update` gem and run its `setup.rb`, so they need network access. On a machine without it, fetch the release archive from the [download page](https://rubygems.org/pages/download) elsewhere, copy it over, then unpack it and install from the unpacked directory:
+
+    ruby setup.rb
+
+Run `ruby setup.rb --help` for the available options.
+
+Updating Bundler
+----------------
+
+To install the latest Bundler:
+
+    gem install bundler
+
+Bundler is a [default gem](/default-gems-and-bundled-gems), so every Ruby installation always contains a version of it that cannot be uninstalled. Installing a newer version does not replace the default one. Both stay available.
+
+Which Bundler version runs
+--------------------------
+
+A project's `Gemfile.lock` records the Bundler version that created it under `BUNDLED WITH`. When you run `bundle` commands in that project, Bundler automatically switches to the recorded version if it is installed, even when a newer version is present. See [Bundler compatibility](/bundler-compatibility) for the Ruby and RubyGems versions each Bundler release supports.

--- a/rubygems-basics.md
+++ b/rubygems-basics.md
@@ -2,7 +2,7 @@
 layout: default
 title: RubyGems Basics
 url: /rubygems-basics
-previous: /
+previous: /installation
 next: /getting_started
 ---
 


### PR DESCRIPTION
The guides have no page explaining how to get RubyGems and Bundler or how to update them. Tools like uv and cargo lead with installation, and a reader arriving here has to piece that together from the download page and passing mentions in other guides.

This adds `/installation` as the first page under Getting Started. It states that both tools ship with Ruby, points at ruby-lang.org for installing Ruby itself, and covers `gem update --system` including a specific version and the offline path documented on the rubygems.org download page, `gem install bundler` with a note that Bundler is a default gem, and the `BUNDLED WITH` switch with a pointer to `/bundler-compatibility`. No version numbers are hardcoded. The `previous` and `next` frontmatter in `index.md` and `rubygems-basics.md` are relinked so the navigation loop stays closed.
