### PR TITLE
Add a CI guide page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -184,6 +184,7 @@
             <li><a class="sidenav-link" data-sidenav href="/rails">How to use Bundler with Rails</a></li>
             <li><a class="sidenav-link" data-sidenav href="/sinatra">How to use Bundler with Sinatra</a></li>
             <li><a class="sidenav-link" data-sidenav href="/bundler_docker_guide">How to use Bundler with Docker</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/ci">How to use Bundler in CI</a></li>
             <li><a class="sidenav-link" data-sidenav href="/rubymotion">How to use Bundler with RubyMotion</a></li>
           </ul>
           <h4 class="font-semibold tracking-[0.08em] uppercase text-xs text-neutral-500 pt-3 pb-1">Hosting &amp; Sources</h4>

--- a/bundler_docker_guide.md
+++ b/bundler_docker_guide.md
@@ -3,7 +3,7 @@ layout: default
 title: How to use Bundler with Docker
 url: /bundler_docker_guide
 previous: /sinatra
-next: /rubymotion
+next: /ci
 ---
 
 ## Introduction

--- a/ci.md
+++ b/ci.md
@@ -68,7 +68,7 @@ Dependency bots and cooldown
 
 If CI runs against pull requests opened by a dependency bot, align the bot's update delay with the [cooldown](/cooldown) configured in Bundler. Otherwise the bot proposes versions that `bundle install` refuses to resolve, or bypasses the waiting period that cooldown is meant to enforce.
 
-Dependabot supports a `cooldown` block for version updates in `dependabot.yml`:
+On GitHub, Dependabot supports a `cooldown` block for version updates in `dependabot.yml`:
 
     version: 2
     updates:
@@ -79,7 +79,7 @@ Dependabot supports a `cooldown` block for version updates in `dependabot.yml`:
         cooldown:
           default-days: 7
 
-The `cooldown` block also accepts `semver-major-days`, `semver-minor-days`, and `semver-patch-days` to set different delays per update type, and `include` and `exclude` lists to scope which dependencies it applies to. Renovate offers the same control through `minimumReleaseAge`, a duration string such as `"7 days"`. In both cases, use the same number of days as your Bundler cooldown. See [the cooldown guide](/cooldown) for how the Bundler side works.
+The `cooldown` block also accepts `semver-major-days`, `semver-minor-days`, and `semver-patch-days` to set different delays per update type, and `include` and `exclude` lists to scope which dependencies it applies to. Renovate, which runs on both GitHub and GitLab, offers the same control through `minimumReleaseAge`, a duration string such as `"7 days"`. In both cases, use the same number of days as your Bundler cooldown. See [the cooldown guide](/cooldown) for how the Bundler side works.
 
 Publishing from CI
 ------------------

--- a/ci.md
+++ b/ci.md
@@ -79,7 +79,20 @@ On GitHub, Dependabot supports a `cooldown` block for version updates in `depend
         cooldown:
           default-days: 7
 
-The `cooldown` block also accepts `semver-major-days`, `semver-minor-days`, and `semver-patch-days` to set different delays per update type, and `include` and `exclude` lists to scope which dependencies it applies to. Renovate, which runs on both GitHub and GitLab, offers the same control through `minimumReleaseAge`, a duration string such as `"7 days"`. In both cases, use the same number of days as your Bundler cooldown. See [the cooldown guide](/cooldown) for how the Bundler side works.
+The `cooldown` block also accepts `semver-major-days`, `semver-minor-days`, and `semver-patch-days` to set different delays per update type, and `include` and `exclude` lists to scope which dependencies it applies to.
+
+Renovate, which runs on both GitHub and GitLab, offers the same control through `minimumReleaseAge`, a duration string such as `"7 days"`. Set it in `renovate.json`, either at the top level or scoped to Bundler:
+
+    {
+      "packageRules": [
+        {
+          "matchManagers": ["bundler"],
+          "minimumReleaseAge": "7 days"
+        }
+      ]
+    }
+
+In both cases, use the same number of days as your Bundler cooldown. See [the cooldown guide](/cooldown) for how the Bundler side works.
 
 Publishing from CI
 ------------------

--- a/ci.md
+++ b/ci.md
@@ -19,7 +19,7 @@ Use the [ruby/setup-ruby](https://github.com/ruby/setup-ruby) action. With `bund
       test:
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v5
+          - uses: actions/checkout@v7
           - uses: ruby/setup-ruby@v1
             with:
               bundler-cache: true
@@ -31,10 +31,10 @@ The `ruby-version` input can be omitted if the repository has a `.ruby-version`,
       test:
         strategy:
           matrix:
-            ruby: ["3.2", "3.3", "3.4"]
+            ruby: ["3.3", "3.4", "4.0"]
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v5
+          - uses: actions/checkout@v7
           - uses: ruby/setup-ruby@v1
             with:
               ruby-version: ${{ matrix.ruby }}
@@ -49,7 +49,7 @@ GitLab CI
 On GitLab, install gems into the project directory and cache that path, keyed on `Gemfile.lock` so the cache is invalidated when dependencies change:
 
     test:
-      image: ruby:3.4
+      image: ruby:4.0
       cache:
         key:
           files:

--- a/ci.md
+++ b/ci.md
@@ -8,7 +8,7 @@ next: /rubymotion
 
 <em class="text-neutral-600">How to install gems quickly and reproducibly on GitHub Actions, GitLab CI, and other CI systems.</em>
 
-A CI job needs the same gems as your development machine, installed from scratch on every run. The recipe is the same everywhere. Check in your `Gemfile.lock`, cache installed gems keyed on that lockfile, and configure Bundler through `BUNDLE_*` environment variables instead of running `bundle config` in each job.
+A CI job needs the same gems as your development machine, installed from scratch on every run. The recipe is the same everywhere. Cache installed gems, keyed on the `Gemfile.lock` when the repository has one, and configure Bundler through `BUNDLE_*` environment variables instead of running `bundle config` in each job.
 
 GitHub Actions
 --------------

--- a/ci.md
+++ b/ci.md
@@ -1,0 +1,87 @@
+---
+layout: default
+title: How to use Bundler in CI
+url: /ci
+previous: /bundler_docker_guide
+next: /rubymotion
+---
+
+<em class="text-neutral-600">How to install gems quickly and reproducibly on GitHub Actions, GitLab CI, and other CI systems.</em>
+
+A CI job needs the same gems as your development machine, installed from scratch on every run. The recipe is the same everywhere. Check in your `Gemfile.lock`, cache installed gems keyed on that lockfile, and configure Bundler through `BUNDLE_*` environment variables instead of running `bundle config` in each job.
+
+GitHub Actions
+--------------
+
+Use the [ruby/setup-ruby](https://github.com/ruby/setup-ruby) action. With `bundler-cache: true` it runs `bundle install` for you and caches the installed gems, so you do not need a separate `gem install bundler` or `bundle install` step. When a `Gemfile.lock` is present, it installs in deployment mode, so the job fails if the lockfile is out of date instead of silently resolving new versions.
+
+    jobs:
+      test:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v5
+          - uses: ruby/setup-ruby@v1
+            with:
+              bundler-cache: true
+          - run: bundle exec rake
+
+The `ruby-version` input can be omitted if the repository has a `.ruby-version`, `.tool-versions`, or `mise.toml` file. To test against several Ruby versions, use a matrix:
+
+    jobs:
+      test:
+        strategy:
+          matrix:
+            ruby: ["3.2", "3.3", "3.4"]
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v5
+          - uses: ruby/setup-ruby@v1
+            with:
+              ruby-version: ${{ matrix.ruby }}
+              bundler-cache: true
+          - run: bundle exec rake
+
+To test against multiple Gemfiles, set `BUNDLE_GEMFILE` in a job-level `env` block (for example from a matrix value) so that both `setup-ruby` and later steps use the same Gemfile.
+
+GitLab CI
+---------
+
+On GitLab, install gems into the project directory and cache that path, keyed on `Gemfile.lock` so the cache is invalidated when dependencies change:
+
+    test:
+      image: ruby:3.4
+      cache:
+        key:
+          files:
+            - Gemfile.lock
+        paths:
+          - vendor/ruby
+      script:
+        - bundle config set --local path 'vendor/ruby'
+        - bundle install
+        - bundle exec rake
+
+Setting `BUNDLE_PATH: vendor/ruby` and `BUNDLE_FROZEN: "true"` in the `variables` block is an equivalent alternative to the `bundle config` line, and keeps the configuration visible in one place.
+
+Dependency bots and cooldown
+----------------------------
+
+If CI runs against pull requests opened by a dependency bot, align the bot's update delay with the [cooldown](/cooldown) configured in Bundler. Otherwise the bot proposes versions that `bundle install` refuses to resolve, or bypasses the waiting period that cooldown is meant to enforce.
+
+Dependabot supports a `cooldown` block for version updates in `dependabot.yml`:
+
+    version: 2
+    updates:
+      - package-ecosystem: "bundler"
+        directory: "/"
+        schedule:
+          interval: "weekly"
+        cooldown:
+          default-days: 7
+
+The `cooldown` block also accepts `semver-major-days`, `semver-minor-days`, and `semver-patch-days` to set different delays per update type, and `include` and `exclude` lists to scope which dependencies it applies to. Renovate offers the same control through `minimumReleaseAge`, a duration string such as `"7 days"`. In both cases, use the same number of days as your Bundler cooldown. See [the cooldown guide](/cooldown) for how the Bundler side works.
+
+Publishing from CI
+------------------
+
+To release gems from a CI pipeline without long-lived API keys, see [Trusted Publishing](/trusted-publishing).

--- a/rubymotion.md
+++ b/rubymotion.md
@@ -2,7 +2,7 @@
 layout: default
 title: How to use Bundler with RubyMotion
 url: /rubymotion
-previous: /bundler_docker_guide
+previous: /ci
 next: /run-your-own-gem-server
 ---
 


### PR DESCRIPTION
Part of the guides restructuring plan (step 3-1).

Adds `/ci`, a guide for running Bundler in CI. It covers `ruby/setup-ruby` with `bundler-cache: true` on GitHub Actions including a matrix example, lockfile-keyed caching on GitLab CI following the official GitLab example, and aligning dependency bot delays with Bundler's own cooldown setting. Dependabot's `cooldown` block and Renovate's `minimumReleaseAge` are both shown with minimal config examples, linking to `/cooldown` for the Bundler side. Publishing from CI points to `/trusted-publishing`.

The page is inserted after the Docker guide in the sidebar and in the previous/next chain.

Generated with [Claude Code](https://claude.com/claude-code)
