### PR TITLE
Fix binstubs usage and clarify extension gem layout

### DIFF
--- a/gems-with-extensions.md
+++ b/gems-with-extensions.md
@@ -37,12 +37,14 @@ example we'll use "my_malloc" for the name.
 
 Some extensions will be partially written in C and partially written in ruby.
 If you are going to support multiple languages, such as C and Java extensions,
-you should put the C-specific ruby files under the `ext/` directory as well in a
-`lib/` directory.
+put the ruby files that are specific to the C extension in a `lib/` directory
+under the extension's directory (`ext/my_malloc/lib/` here), not in the
+top-level `lib/` directory.
 
     Rakefile
     ext/my_malloc/extconf.rb               # extension configuration
     ext/my_malloc/my_malloc.c              # extension source
+    ext/my_malloc/lib/my_malloc/helper.rb  # ruby code for the C extension
     lib/my_malloc.rb                       # generic features
 
 When the extension is built the files in `ext/my_malloc/lib/` will be installed

--- a/getting_started.md
+++ b/getting_started.md
@@ -74,10 +74,11 @@ However, this is unreliable and is the source of considerable pain.
 Even if it looks like it works, it may not work in the future or
 on another machine.
 
-Finally, if you want a way to get a shortcut to gems in your bundle:
+Finally, if you want a shortcut to the executables of a gem in your
+bundle, generate binstubs for it:
 
 ~~~
-$ bundle install --binstubs
+$ bundle binstubs rspec-core
 $ bin/rspec spec/models
 ~~~
 


### PR DESCRIPTION
`bundle install --binstubs` was removed and now errors out. The getting started guide now uses `bundle binstubs rspec-core` instead.

In the "Gem layout" section of the gems with extensions guide, the paragraph after the directory listing referred to `ext/my_malloc/lib/`, which the listing did not contain, and the sentence about C-specific ruby files was hard to parse. The listing now includes that directory and the text states plainly that ruby files specific to the C extension go under `ext/my_malloc/lib/`, which mkmf installs into `lib/` at build time.

I also verified #449: a gist with the gemspec at its root and `require_paths = ["."]` installs and requires fine with current Bundler, so the `:gist` example in the git guide stays as is.

Fixes #429
Fixes #271
