### PR TITLE
Use bundle binstubs in workflow and deploying guides

### DIFF
--- a/bundler_workflow.md
+++ b/bundler_workflow.md
@@ -211,10 +211,11 @@ However, this is unreliable and is the source of considerable pain.
 Even if it looks like it works, it may not work in the future or
 on another machine.
 
-Finally, if you want a way to get a shortcut to gems in your bundle:
+Finally, if you want a shortcut to the executables of a gem in your
+bundle, generate binstubs for it:
 
 ~~~
-$ bundle install --binstubs
+$ bundle binstubs rspec-core
 $ bin/rspec spec/models
 ~~~
 

--- a/deploying.md
+++ b/deploying.md
@@ -41,9 +41,9 @@ from gems in the bundle
 $ bundle exec rake db:setup
 ~~~
 
-Alternatively, you can use the `--binstubs` option on the
-install command to generate executable binaries that can be used instead of
-`bundle exec`.
+Alternatively, you can run `bundle binstubs GEM_NAME` (or
+`bundle binstubs --all`) to generate executable binaries that can be used
+instead of `bundle exec`.
 
 <a href="/command-reference/bundle-exec/" class="btn btn-primary">Learn More: Executables</a>
 


### PR DESCRIPTION
`bundler_workflow.md` and `deploying.md` still recommend the `--binstubs` option of `bundle install`, which has been removed and now errors with "The `--binstubs` option has been removed in favor of `bundle binstubs --all`". Rewrite both spots to the current `bundle binstubs` usage, matching the command reference and the `getting_started.md` fix in #506.
