### PR TITLE
Add a Gemfile and gemspec concept guide

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -200,6 +200,7 @@
           <h3 class="font-bold tracking-[0.04em] text-lg text-neutral-600 pt-5 pb-2">Concepts</h3>
           <ul>
             <li><a class="sidenav-link" data-sidenav href="/what-is-a-gem">What is a gem?</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/gemfile-and-gemspec">Gemfile and gemspec</a></li>
             <li><a class="sidenav-link" data-sidenav href="/default-gems-and-bundled-gems">Default gems and bundled gems</a></li>
             <li><a class="sidenav-link" data-sidenav href="/cve">Common Vulnerabilities and Exposures</a></li>
           </ul>

--- a/default-gems-and-bundled-gems.md
+++ b/default-gems-and-bundled-gems.md
@@ -2,7 +2,7 @@
 layout: default
 title: Default Gems and Bundled Gems
 url: /default-gems-and-bundled-gems
-previous: /what-is-a-gem
+previous: /gemfile-and-gemspec
 next: /cve
 ---
 

--- a/gemfile-and-gemspec.md
+++ b/gemfile-and-gemspec.md
@@ -20,12 +20,13 @@ A Gemfile is the input to [Bundler](/getting_started). It declares the set of ge
 Declaring dependencies
 ----------------------
 
-A gemspec declares the gems your gem needs at runtime with `add_dependency`:
+A gemspec declares dependencies with `add_dependency` for gems needed at runtime and `add_development_dependency` for gems needed only to work on the gem itself:
 
 ~~~ruby
 Gem::Specification.new do |s|
   # ...
   s.add_dependency "activesupport", ">= 7.0"
+  s.add_development_dependency "rspec", ">= 3.0"
 end
 ~~~
 
@@ -54,7 +55,7 @@ gem "rspec", "~> 3.13"
 gem "rubocop"
 ~~~
 
-The `gemspec` method treats the gemspec's runtime dependencies as Gemfile entries in the default group and adds the gem itself as a `path` dependency so your tests can require it. The gemspec format also supports `add_development_dependency`, and the `gemspec` method pulls those in too, but prefer the Gemfile for development dependencies. A gemspec can only name a gem and a version requirement, while the Gemfile lets you adjust each dependency to the needs of the library you are developing, with groups, git or path sources, and platform conditions. This is the layout `bundle gem` generates. See [Bundler in gems](/rubygems) for the `gemspec` method's options and [Make your own gem](/make-your-own-gem) for the full workflow.
+The `gemspec` method treats the gemspec's runtime dependencies as Gemfile entries in the default group, puts any `add_development_dependency` entries in the `:development` group, and adds the gem itself as a `path` dependency so your tests can require it. Declaring development dependencies only in the gemspec works fine on its own, but once both files are in play, prefer the Gemfile for them. A gemspec can only name a gem and a version requirement, while the Gemfile lets you adjust each dependency to the needs of the library you are developing, with groups, git or path sources, and platform conditions. This is the layout `bundle gem` generates. See [Bundler in gems](/rubygems) for the `gemspec` method's options and [Make your own gem](/make-your-own-gem) for the full workflow.
 
 Building a library vs. building an application
 ----------------------------------------------
@@ -68,6 +69,6 @@ Which file gets what
 |------------------------|---------------|
 | The gem's name, version, and metadata | gemspec |
 | Gems your gem needs at runtime | gemspec, `add_dependency` |
-| Gems needed only to develop your gem | Gemfile |
+| Gems needed only to develop your gem | gemspec, `add_development_dependency`, or the Gemfile when you use both files |
 | Gems your application uses | Gemfile |
 | Exact versions for reproducible installs | `Gemfile.lock`, written by Bundler |

--- a/gemfile-and-gemspec.md
+++ b/gemfile-and-gemspec.md
@@ -1,0 +1,71 @@
+---
+layout: default
+title: Gemfile and gemspec
+url: /gemfile-and-gemspec
+previous: /what-is-a-gem
+next: /default-gems-and-bundled-gems
+---
+
+<em class="text-neutral-600">Which file your dependencies belong in, and why Ruby projects have two of them.</em>
+
+Ruby projects declare dependencies in two different files, a `.gemspec` and a `Gemfile`. Newcomers often ask which one to use. The answer depends on what you are building. A gemspec describes a gem. A Gemfile describes an application's environment.
+
+Two files, two jobs
+-------------------
+
+A gemspec is the manifest of a gem. It declares the gem's name, version, summary, files, and the other gems it needs, and it is packaged into the `.gem` file that `gem build` produces. When someone installs your gem, RubyGems reads the gemspec to decide what else to install. Every gem has one. The [Specification Reference](/specification-reference) covers all of its fields.
+
+A Gemfile is the input to [Bundler](/getting_started). It declares the set of gems an application uses, and `bundle install` resolves that set into an exact snapshot recorded in `Gemfile.lock`. The Gemfile exists so the same versions can be reproduced on every machine that runs the application. See [How to manage dependencies with Bundler](/dependency_management) and the [Gemfile Reference](/gemfile).
+
+Declaring dependencies
+----------------------
+
+A gemspec declares dependencies with `add_dependency` for gems needed at runtime and `add_development_dependency` for gems needed only to work on the gem itself:
+
+~~~ruby
+Gem::Specification.new do |s|
+  # ...
+  s.add_dependency "activesupport", ">= 7.0"
+  s.add_development_dependency "rspec", ">= 3.0"
+end
+~~~
+
+A Gemfile declares dependencies with the `gem` method:
+
+~~~ruby
+source "https://rubygems.org"
+
+gem "rails", "8.1.3.1"
+gem "nokogiri", "~> 1.19"
+~~~
+
+The version constraints look alike but pull in opposite directions. A gem's constraints should stay wide, because your gem must coexist with every other gem an application installs alongside it, and strict constraints cause resolution conflicts for your users. See [Optimistic vs. pessimistic version constraints](/patterns#optimistic-vs-pessimistic-version-constraints). An application can afford loose constraints in its Gemfile, because exactness comes from `Gemfile.lock` rather than from the requirements themselves.
+
+Using both while developing a gem
+---------------------------------
+
+While developing a gem you still want Bundler to set up a working environment, so a gem's repository usually contains both files. The convention is to keep the gemspec as the single place where dependencies are declared, and to put the `gemspec` method in the Gemfile:
+
+~~~ruby
+source "https://rubygems.org"
+
+gemspec
+~~~
+
+Bundler then treats the gemspec's runtime dependencies as Gemfile entries in the default group, puts its development dependencies in the `:development` group, and adds the gem itself as a `path` dependency so your tests can require it. This is exactly the layout `bundle gem` generates. See [Bundler in gems](/rubygems) for the `gemspec` method's options and [Make your own gem](/make-your-own-gem) for the full workflow.
+
+Building a library vs. building an application
+----------------------------------------------
+
+The deeper difference is who resolves the versions. An application is the end of the dependency chain, so it locks: `Gemfile.lock` is committed and every deployment installs exactly those versions. A library is a link in someone else's chain, so it cannot lock. When an application depends on your gem, Bundler ignores any `Gemfile` and `Gemfile.lock` shipped inside it and resolves your gemspec's runtime dependencies together with everything else in the application's Gemfile. Your gem will run with whatever versions that resolution picks, which is why wide constraints and testing against a range of versions matter for libraries. Whether to commit the lockfile of a gem's own repository is a separate tradeoff, discussed in the [FAQs](/faqs#using-gemfiles-inside-gems).
+
+Which file gets what
+--------------------
+
+| What you are declaring | Where it goes |
+|------------------------|---------------|
+| The gem's name, version, and metadata | gemspec |
+| Gems your gem needs at runtime | gemspec, `add_dependency` |
+| Gems needed only to develop your gem | gemspec, `add_development_dependency` |
+| Gems your application uses | Gemfile |
+| Exact versions for reproducible installs | `Gemfile.lock`, written by Bundler |

--- a/gemfile-and-gemspec.md
+++ b/gemfile-and-gemspec.md
@@ -20,13 +20,12 @@ A Gemfile is the input to [Bundler](/getting_started). It declares the set of ge
 Declaring dependencies
 ----------------------
 
-A gemspec declares dependencies with `add_dependency` for gems needed at runtime and `add_development_dependency` for gems needed only to work on the gem itself:
+A gemspec declares the gems your gem needs at runtime with `add_dependency`:
 
 ~~~ruby
 Gem::Specification.new do |s|
   # ...
   s.add_dependency "activesupport", ">= 7.0"
-  s.add_development_dependency "rspec", ">= 3.0"
 end
 ~~~
 
@@ -44,15 +43,18 @@ The version constraints look alike but pull in opposite directions. A gem's cons
 Using both while developing a gem
 ---------------------------------
 
-While developing a gem you still want Bundler to set up a working environment, so a gem's repository usually contains both files. The convention is to keep the gemspec as the single place where dependencies are declared, and to put the `gemspec` method in the Gemfile:
+While developing a gem you still want Bundler to set up a working environment, so a gem's repository usually contains both files. The convention is to declare runtime dependencies in the gemspec, pull them into the bundle with the `gemspec` method, and declare development dependencies directly in the Gemfile:
 
 ~~~ruby
 source "https://rubygems.org"
 
 gemspec
+
+gem "rspec", "~> 3.13"
+gem "rubocop"
 ~~~
 
-Bundler then treats the gemspec's runtime dependencies as Gemfile entries in the default group, puts its development dependencies in the `:development` group, and adds the gem itself as a `path` dependency so your tests can require it. This is exactly the layout `bundle gem` generates. See [Bundler in gems](/rubygems) for the `gemspec` method's options and [Make your own gem](/make-your-own-gem) for the full workflow.
+The `gemspec` method treats the gemspec's runtime dependencies as Gemfile entries in the default group and adds the gem itself as a `path` dependency so your tests can require it. The gemspec format also supports `add_development_dependency`, and the `gemspec` method pulls those in too, but prefer the Gemfile for development dependencies. A gemspec can only name a gem and a version requirement, while the Gemfile lets you adjust each dependency to the needs of the library you are developing, with groups, git or path sources, and platform conditions. This is the layout `bundle gem` generates. See [Bundler in gems](/rubygems) for the `gemspec` method's options and [Make your own gem](/make-your-own-gem) for the full workflow.
 
 Building a library vs. building an application
 ----------------------------------------------
@@ -66,6 +68,6 @@ Which file gets what
 |------------------------|---------------|
 | The gem's name, version, and metadata | gemspec |
 | Gems your gem needs at runtime | gemspec, `add_dependency` |
-| Gems needed only to develop your gem | gemspec, `add_development_dependency` |
+| Gems needed only to develop your gem | Gemfile |
 | Gems your application uses | Gemfile |
 | Exact versions for reproducible installs | `Gemfile.lock`, written by Bundler |

--- a/make-your-own-gem.md
+++ b/make-your-own-gem.md
@@ -136,7 +136,9 @@ This creates a directory with the following structure:
 
  * **Gemfile**: Manages gem dependencies for development. Contains a `gemspec` line
 meaning that Bundler will include dependencies specified in _foodie.gemspec_ too.
-It’s best practice to specify all dependencies in the _gemspec_.
+Runtime dependencies belong in the _gemspec_, while development dependencies are
+declared here. See [Gemfile and gemspec](/gemfile-and-gemspec) for how the two
+files divide the work.
 
  * **Rakefile**: Includes Bundler’s `build`, `install` and `release` Rake tasks
 by way of calling `Bundler::GemHelper.install_tasks`.
@@ -305,7 +307,9 @@ but not at runtime:
 When using Bundler, running `bundle install` will resolve and install all
 dependencies specified in the gemspec. Anyone who runs
 `gem install yourgemname --dev` will get the development dependencies installed
-too.
+too. If your gem has a Gemfile alongside the gemspec, prefer declaring
+development dependencies in the Gemfile instead. See
+[Gemfile and gemspec](/gemfile-and-gemspec) for the reasoning.
 
 Writing tests
 --------------

--- a/patterns.md
+++ b/patterns.md
@@ -119,6 +119,10 @@ and `add_development_dependency`:
       s.add_development_dependency "bourne",
         [">= 0"]
 
+If you develop your gem with Bundler and a Gemfile, prefer declaring
+development dependencies in the Gemfile rather than in the gemspec. See
+[Gemfile and gemspec](/gemfile-and-gemspec) for the reasoning.
+
 ### Don't use `gem` from within your gem
 
 You may have seen some code like this around to make sure you're using a

--- a/rubygems.md
+++ b/rubygems.md
@@ -26,6 +26,7 @@ gem "rubocop", "0.79.0"
 
 In this Gemfile, the `gemspec` method imports gems listed with `add_runtime_dependency` in the `my_gem.gemspec` file, and it also installs rspec and rubocop to test and develop the gem.
 All dependencies from the gemspec and Gemfile will be installed by `bundle install`, but rspec and rubocop will not be included by `gem install mygem` or `bundle add mygem`.
+Declaring development dependencies in the Gemfile like this, rather than with `add_development_dependency` in the gemspec, is the recommended layout. See [Gemfile and gemspec](/gemfile-and-gemspec) for the reasoning.
 Runtime dependencies in your gemspec are treated as if they are listed in your Gemfile, and development dependencies are added by default to the group, `:development`.
 You can change that group with the `:development_group` option:
 

--- a/what-is-a-gem.md
+++ b/what-is-a-gem.md
@@ -3,7 +3,7 @@ layout: default
 title: What is a gem?
 url: /what-is-a-gem/
 previous: /git_bisect
-next: /default-gems-and-bundled-gems
+next: /gemfile-and-gemspec
 ---
 
 <em class="text-neutral-600">Unpack the mystery behind what's in a RubyGem.</em>


### PR DESCRIPTION
This adds a new Concepts page explaining the difference between a gemspec and a Gemfile, the Ruby counterpart of Cargo's "Cargo.toml vs Cargo.lock" page. It covers what each file declares, why library constraints stay wide while applications lock exact versions, the `gemspec` directive convention for gem development, and why gems do not ship a `Gemfile.lock`. For gems that use both files, the page recommends declaring development dependencies in the Gemfile, and the `make-your-own-gem`, `patterns`, and Bundler in gems pages are updated to match. Details stay delegated by links to the Specification Reference, the `Gemfile` reference, Patterns, and the FAQs. The page is inserted into the sidebar and the previous/next chain after "What is a gem?".

Refs #196
