### PR TITLE
Move site-only gems to a Bundler group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,17 +2,20 @@
 
 source "https://rubygems.org"
 
-gem "jekyll", "~> 4.2"
-gem "jekyll-redirect-from", "~> 0.16"
 gem "mdl", "~> 0.11.0"
 gem "nokogiri", "~> 1.19"
 gem "nronn", "~> 0.11"
 gem "rake", "~> 13.0"
 gem "rdoc", "~> 6.4"
-gem "webrick", "~> 1.8"
 gem "csv", "~> 3.3"
 gem "base64", "~> 0.3"
 gem "logger", "~> 1.7"
+
+group :site do
+  gem "jekyll", "~> 4.2"
+  gem "jekyll-redirect-from", "~> 0.16"
+  gem "webrick", "~> 1.8"
+end
 
 group :jekyll_plugins do
   gem "jekyll-tailwindcss"


### PR DESCRIPTION
`rake release` in rubygems/rubygems clones this repository and runs `bundle install` before `rake command_reference` and `rake spec_guide`. Those tasks only need `rdoc`, `erb`, `nronn`, and `nokogiri`, but the default group pulled in `jekyll`, which depends on `google-protobuf` through `jekyll-sass-converter` and `sass-embedded`. The precompiled `google-protobuf` variants cap `required_ruby_version` below 3.5.dev, so `bundle install` became unresolvable on Ruby 4.0.6 and blocked the RubyGems 4.0.18 release.

This moves `jekyll`, `jekyll-redirect-from`, and `webrick` to a `:site` group so the release tooling can install with `BUNDLE_WITHOUT=site:jekyll_plugins`. The lockfile is unchanged. The deploy and CI workflows install all groups, so the site build is unaffected. The matching `guides:update` change in `rubygems/rubygems` will follow in a separate PR.

Generated with [Claude Code](https://claude.com/claude-code)
