### PR TITLE
Fix previous/next links on specification-reference

### DIFF
--- a/specification-reference.md
+++ b/specification-reference.md
@@ -2,8 +2,8 @@
 layout: default
 title: Specification Reference
 url: /specification-reference
-previous: /patterns
-next: /command-reference
+previous: /gemfile_ruby
+next: /rubygems-org-api
 ---
 
 


### PR DESCRIPTION
The chain rebuilt in #496 left `specification-reference.md` pointing at its old neighbors. `gemfile_ruby.md` links here as `next` and `rubygems-org-api.md` links here as `previous`, while `command-reference.md` is already paired with `cve.md`. This updates both `previous` and `next` to mirror those pages. I verified with a script that every `previous`/`next` pair across all 92 pages (including `command-reference/*.html`) is now symmetric.
