### PR TITLE
Add sitemap.xml and robots.txt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "logger", "~> 1.7"
 group :site do
   gem "jekyll", "~> 4.2"
   gem "jekyll-redirect-from", "~> 0.16"
+  gem "jekyll-sitemap", "~> 1.4"
   gem "webrick", "~> 1.8"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,8 @@ GEM
       jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (3.1.0)
       sass-embedded (~> 1.75)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-tailwindcss (0.7.0)
       tailwindcss-ruby
     jekyll-watch (2.2.1)
@@ -248,6 +250,7 @@ DEPENDENCIES
   csv (~> 3.3)
   jekyll (~> 4.2)
   jekyll-redirect-from (~> 0.16)
+  jekyll-sitemap (~> 1.4)
   jekyll-tailwindcss
   logger (~> 1.7)
   mdl (~> 0.11.0)
@@ -303,6 +306,7 @@ CHECKSUMS
   jekyll (4.4.1) sha256=4c1144d857a5b2b80d45b8cf5138289579a9f8136aadfa6dd684b31fe2bc18c1
   jekyll-redirect-from (0.16.0) sha256=6635cae569ef9b0f90ffb71ec014ba977177fafb44d32a2b0526288d4d9be6db
   jekyll-sass-converter (3.1.0) sha256=83925d84f1d134410c11d0c6643b0093e82e3a3cf127e90757a85294a3862443
+  jekyll-sitemap (1.4.0) sha256=0de08c5debc185ea5a8f980e1025c7cd3f8e0c35c8b6ef592f15c46235cf4218
   jekyll-tailwindcss (0.7.0) sha256=987eac000d0ef5a23b901927a34c9949066be3f7acd9729643e2f6afb4e30adf
   jekyll-watch (2.2.1) sha256=bc44ed43f5e0a552836245a54dbff3ea7421ecc2856707e8a1ee203a8387a7e1
   json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a

--- a/_config.yml
+++ b/_config.yml
@@ -7,4 +7,5 @@ exclude:
 permalink: "pretty"
 plugins:
 - jekyll-redirect-from
+- jekyll-sitemap
 markdown: kramdown

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://guides.rubygems.org/sitemap.xml


### PR DESCRIPTION
The LLM discoverability scorecard at https://ruby.evilmartians.com/ marks RubyGems Guides as missing a sitemap. This adds `jekyll-sitemap` to generate `sitemap.xml` and a `robots.txt` that allows all crawlers and points to it.

I verified with a local build that `robots.txt` is copied to the output as a static file and `sitemap.xml` lists all guide pages under `https://guides.rubygems.org`.