### PR TITLE
Serve each guide's Markdown source at /<page>.md

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Titillium+Web:ital,wght@0,400;0,600;0,700;1,400;1,600&display=swap" rel="stylesheet">
-  <link href="/stylesheets/styles.css" rel="stylesheet" />
+  {% if page.markdown_url %}<link rel="alternate" type="text/markdown" href="{{ page.markdown_url }}" title="Markdown">
+  {% endif %}<link href="/stylesheets/styles.css" rel="stylesheet" />
   <link href="/pagefind/pagefind-component-ui.css" rel="stylesheet" />
   <script src="/pagefind/pagefind-component-ui.js" type="module"></script>
   <style>

--- a/_plugins/markdown_alternates.rb
+++ b/_plugins/markdown_alternates.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Publishes the Markdown source of every guide next to its HTML page, so
+# /what-is-a-gem/ can also be fetched as /what-is-a-gem.md. The copy is the
+# source with the front matter stripped and Liquid evaluated, matching what
+# the HTML page was rendered from.
+module MarkdownAlternates
+  FRONT_MATTER = Jekyll::Document::YAML_FRONT_MATTER_REGEXP
+
+  def self.alternate_url(page)
+    return unless File.extname(page.name) == ".md"
+
+    page.url == "/" ? "/index.md" : "#{page.url.chomp("/")}.md"
+  end
+
+  def self.markdown_for(site, page)
+    raw = File.read(site.in_source_dir(page.path))
+    raw = Regexp.last_match.post_match if raw =~ FRONT_MATTER
+
+    payload = site.site_payload
+    payload["page"] = page.to_liquid
+    site.liquid_renderer.file(page.path)
+        .parse(raw)
+        .render!(payload, registers: { site: site, page: page })
+  end
+end
+
+# Runs before generators, so only hand-written and committed pages are
+# tagged; pages generated later (jekyll-redirect-from) get no alternate.
+Jekyll::Hooks.register :site, :post_read do |site|
+  site.pages.each do |page|
+    url = MarkdownAlternates.alternate_url(page)
+    page.data["markdown_url"] = url if url
+  end
+end
+
+Jekyll::Hooks.register :site, :post_write do |site|
+  site.pages.each do |page|
+    url = page.data["markdown_url"]
+    next unless url
+
+    path = site.in_dest_dir(url.delete_prefix("/"))
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, MarkdownAlternates.markdown_for(site, page))
+  end
+end


### PR DESCRIPTION
Fetching a guide as Markdown required scraping the rendered HTML. LLM-oriented crawlers and the [ruby.evilmartians.com](https://ruby.evilmartians.com/) discoverability scorecard expect a `.md` route next to each page, and we had none.

A new Jekyll plugin writes the front-matter-stripped, Liquid-evaluated source of every Markdown page to `_site/<permalink>.md`, so `/what-is-a-gem/` is now also available as `/what-is-a-gem.md`. Each HTML page advertises its copy via `<link rel="alternate" type="text/markdown">`. Pages without a Markdown source get no route: the ronn-generated `command-reference/*` pages and the pages generated by `jekyll-redirect-from`. `specification-reference.md` is included even though its rdoc-generated body is mostly inline HTML, which Markdown permits.

Verified with a local `jekyll build`: 62 `.md` files, Liquid loops evaluated (`bundler_known_plugins.md`), and no spurious routes for redirect pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
