### PR TITLE
Add llms.txt

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -1,5 +1,9 @@
-# Site navigation, rendered as the sidebar in _layouts/default.html.
-# Add new pages here to appear in the sidebar.
+# Site navigation, rendered as the sidebar in _layouts/default.html and as
+# the page list in llms.txt. Add new pages here to appear in both.
+#
+# Each item: url, label, and an optional description. llms.txt prefers the
+# page's leading <em class="text-neutral-600"> summary; description is the
+# fallback for pages without one.
 
 - title: "Getting Started"
   items:
@@ -9,6 +13,7 @@
       label: "RubyGems Basics"
     - url: /getting_started
       label: "Getting Started with Bundler"
+      description: "First steps with Bundler: declare dependencies in a Gemfile and run your code with them."
     - url: /make-your-own-gem
       label: "Make your own gem"
     - url: /publishing
@@ -20,20 +25,28 @@
       items:
         - url: /using_bundler_in_applications
           label: "How to manage application dependencies with Bundler"
+          description: "The day-to-day Bundler workflow for applications, from installing to updating and version control."
         - url: /dependency_management
           label: "How to manage dependencies with Bundler"
+          description: "Why applications declare dependencies in a Gemfile and how Bundler keeps them consistent."
         - url: /updating_gems
           label: "How to update gems with Bundler"
+          description: "Update the gems in a bundle, one at a time or all at once."
         - url: /groups
           label: "How to manage groups of gems"
+          description: "Organize Gemfile dependencies into groups you can install or require selectively."
         - url: /git
           label: "How to install gems from git repositories"
+          description: "Declare dependencies on gems that live in git repositories."
         - url: /bundler_setup
           label: "How to use Bundler with Ruby"
+          description: "What require \"bundler/setup\" does and how to load the bundled environment in plain Ruby code."
         - url: /bundler_in_a_single_file_ruby_script
           label: "How to use Bundler in a single-file Ruby script"
+          description: "Declare a script's dependencies inline with bundler/inline instead of a separate Gemfile."
         - url: /deploying
           label: "How to deploy bundled applications"
+          description: "Install a bundle reproducibly on servers and in CI with deployment mode."
     - title: "Gem Development"
       items:
         - url: /name-your-gem
@@ -44,10 +57,12 @@
           label: "Gems with Extensions"
         - url: /rubygems
           label: "Bundler in gems"
+          description: "Using Bundler during gem development with the gemspec directive."
     - title: "Publishing & Security"
       items:
         - url: /trusted-publishing
           label: "Trusted Publishing"
+          description: "Publish gems from CI without long-lived API keys using OpenID Connect."
         - url: /setting-up-multifactor-authentication
           label: "Setting up multi-factor authentication"
         - url: /using-mfa-in-command-line
@@ -56,15 +71,20 @@
           label: "Managing owners using UI"
         - url: /organizations
           label: "Organizations"
+          description: "What RubyGems.org organizations are and how they help teams manage gems together."
           children:
             - url: /organizations/getting-started
               label: "Getting Started"
+              description: "Create an organization on RubyGems.org and move your gems into it."
             - url: /organizations/managing-members
               label: "Managing Members"
+              description: "Invite, update, and remove members of a RubyGems.org organization."
             - url: /organizations/roles-and-permissions
               label: "Roles & Permissions"
+              description: "What each organization role can and cannot do."
             - url: /organizations/transferring-gems
               label: "Transferring Gems"
+              description: "Move existing gems into a RubyGems.org organization."
         - url: /removing-a-published-gem
           label: "Removing a Published gem"
         - url: /security
@@ -75,10 +95,13 @@
       items:
         - url: /rails
           label: "How to use Bundler with Rails"
+          description: "Set up and use Bundler in a Rails application."
         - url: /sinatra
           label: "How to use Bundler with Sinatra"
+          description: "Set up and use Bundler in a Sinatra application."
         - url: /bundler_docker_guide
           label: "How to use Bundler with Docker"
+          description: "Build Docker images for bundled Ruby applications, including private gem sources."
         - url: /ci
           label: "How to use Bundler in CI"
     - title: "Hosting & Sources"
@@ -93,6 +116,7 @@
           label: "RubyGems Plugins"
         - url: /bundler_plugins
           label: "How to write a Bundler plugin"
+          description: "Write a Bundler plugin: commands, hooks, and sources."
     - title: "Troubleshooting"
       items:
         - url: /troubleshooting
@@ -101,6 +125,7 @@
           label: "How to troubleshoot RubyGems and Bundler TLS/SSL Issues"
         - url: /git_bisect
           label: "How to use git bisect with Bundler"
+          description: "Track down regressions across gem versions with git bisect and Bundler."
 
 - title: "Concepts"
   items:
@@ -120,6 +145,7 @@
       label: "Default gems and bundled gems"
     - url: /cve
       label: "Common Vulnerabilities and Exposures"
+      description: "How security vulnerabilities in RubyGems are reported, tracked, and disclosed."
 
 - title: "Reference"
   items:
@@ -131,8 +157,10 @@
       label: "Gemfile Reference"
     - url: /gemfile_ruby
       label: "Ruby Directive"
+      description: "Pin the Ruby version an application requires with the Gemfile ruby directive."
     - url: /specification-reference
       label: "Specification Reference"
+      description: "Every attribute of Gem::Specification, generated from the RubyGems source."
     - url: /rubygems-org-api
       label: "RubyGems.org API"
     - url: /rubygems-org-compact-index-api
@@ -141,10 +169,13 @@
       label: "RubyGems.org rate limits"
     - url: /api-key-scopes
       label: "API key scopes"
+      description: "What each RubyGems.org API key scope allows."
     - url: /bundler-compatibility
       label: "Bundler compatibility with Ruby"
+      description: "Which Bundler versions work with which Ruby and RubyGems versions."
     - url: /bundler_known_plugins
       label: "Known Bundler Plugins"
+      description: "A list of known Bundler plugins and what they do."
 
 - title: "Appendix"
   items:

--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -1,0 +1,158 @@
+# Site navigation, rendered as the sidebar in _layouts/default.html.
+# Add new pages here to appear in the sidebar.
+
+- title: "Getting Started"
+  items:
+    - url: /installation
+      label: "Installation"
+    - url: /rubygems-basics
+      label: "RubyGems Basics"
+    - url: /getting_started
+      label: "Getting Started with Bundler"
+    - url: /make-your-own-gem
+      label: "Make your own gem"
+    - url: /publishing
+      label: "Publishing your gem"
+
+- title: "Guides"
+  subsections:
+    - title: "Dependency Management"
+      items:
+        - url: /using_bundler_in_applications
+          label: "How to manage application dependencies with Bundler"
+        - url: /dependency_management
+          label: "How to manage dependencies with Bundler"
+        - url: /updating_gems
+          label: "How to update gems with Bundler"
+        - url: /groups
+          label: "How to manage groups of gems"
+        - url: /git
+          label: "How to install gems from git repositories"
+        - url: /bundler_setup
+          label: "How to use Bundler with Ruby"
+        - url: /bundler_in_a_single_file_ruby_script
+          label: "How to use Bundler in a single-file Ruby script"
+        - url: /deploying
+          label: "How to deploy bundled applications"
+    - title: "Gem Development"
+      items:
+        - url: /name-your-gem
+          label: "Name your gem"
+        - url: /patterns
+          label: "Patterns"
+        - url: /gems-with-extensions
+          label: "Gems with Extensions"
+        - url: /rubygems
+          label: "Bundler in gems"
+    - title: "Publishing & Security"
+      items:
+        - url: /trusted-publishing
+          label: "Trusted Publishing"
+        - url: /setting-up-multifactor-authentication
+          label: "Setting up multi-factor authentication"
+        - url: /using-mfa-in-command-line
+          label: "Using multi-factor authentication in command line"
+        - url: /managing-owners-using-ui
+          label: "Managing owners using UI"
+        - url: /organizations
+          label: "Organizations"
+          children:
+            - url: /organizations/getting-started
+              label: "Getting Started"
+            - url: /organizations/managing-members
+              label: "Managing Members"
+            - url: /organizations/roles-and-permissions
+              label: "Roles & Permissions"
+            - url: /organizations/transferring-gems
+              label: "Transferring Gems"
+        - url: /removing-a-published-gem
+          label: "Removing a Published gem"
+        - url: /security
+          label: "Security Practices"
+        - url: /cooldown
+          label: "How to delay new gem versions with cooldown"
+    - title: "Integrations"
+      items:
+        - url: /rails
+          label: "How to use Bundler with Rails"
+        - url: /sinatra
+          label: "How to use Bundler with Sinatra"
+        - url: /bundler_docker_guide
+          label: "How to use Bundler with Docker"
+        - url: /ci
+          label: "How to use Bundler in CI"
+    - title: "Hosting & Sources"
+      items:
+        - url: /run-your-own-gem-server
+          label: "Run your own gem server"
+        - url: /using-s3-source
+          label: "Using S3 as gem source"
+    - title: "Extending"
+      items:
+        - url: /plugins
+          label: "RubyGems Plugins"
+        - url: /bundler_plugins
+          label: "How to write a Bundler plugin"
+    - title: "Troubleshooting"
+      items:
+        - url: /troubleshooting
+          label: "Troubleshooting common issues"
+        - url: /rubygems_tls_ssl_troubleshooting_guide
+          label: "How to troubleshoot RubyGems and Bundler TLS/SSL Issues"
+        - url: /git_bisect
+          label: "How to use git bisect with Bundler"
+
+- title: "Concepts"
+  items:
+    - url: /what-is-a-gem
+      label: "What is a gem?"
+    - url: /gemfile-and-gemspec
+      label: "Gemfile and gemspec"
+    - url: /gem-installation-and-loading
+      label: "Where gems are installed and how they load"
+    - url: /dependency-resolution
+      label: "How dependency resolution works"
+    - url: /gemfile-lock
+      label: "How Gemfile.lock works"
+    - url: /versioning
+      label: "Versioning and compatibility"
+    - url: /default-gems-and-bundled-gems
+      label: "Default gems and bundled gems"
+    - url: /cve
+      label: "Common Vulnerabilities and Exposures"
+
+- title: "Reference"
+  items:
+    - url: /command-reference
+      label: "gem Command Reference"
+    - url: /command-reference/bundle
+      label: "Bundler Command Reference"
+    - url: /gemfile
+      label: "Gemfile Reference"
+    - url: /gemfile_ruby
+      label: "Ruby Directive"
+    - url: /specification-reference
+      label: "Specification Reference"
+    - url: /rubygems-org-api
+      label: "RubyGems.org API"
+    - url: /rubygems-org-compact-index-api
+      label: "RubyGems.org Compact Index API"
+    - url: /rubygems-org-rate-limits
+      label: "RubyGems.org rate limits"
+    - url: /api-key-scopes
+      label: "API key scopes"
+    - url: /bundler-compatibility
+      label: "Bundler compatibility with Ruby"
+    - url: /bundler_known_plugins
+      label: "Known Bundler Plugins"
+
+- title: "Appendix"
+  items:
+    - url: /faqs
+      label: "Frequently Asked Questions"
+    - url: /resources
+      label: "Resources"
+    - url: /contributing
+      label: "Contributing to RubyGems"
+    - url: /credits
+      label: "Credits"

--- a/_includes/llms_link.txt
+++ b/_includes/llms_link.txt
@@ -1,0 +1,19 @@
+{%- assign item_url = include.item.url | append: '/' -%}
+{%- assign found_page = nil -%}
+{%- for candidate in site.pages -%}
+{%- if candidate.url == include.item.url or candidate.url == item_url -%}
+{%- assign found_page = candidate -%}
+{%- break -%}
+{%- endif -%}
+{%- endfor -%}
+{%- assign description = include.item.description -%}
+{%- if found_page -%}
+{%- assign em_parts = found_page.content | split: '<em class="text-neutral-600">' -%}
+{%- if em_parts.size > 1 -%}
+{%- assign description = em_parts[1] | split: '</em>' | first | strip_html | strip -%}
+{%- endif -%}
+{%- endif -%}
+{%- capture newline %}
+{% endcapture -%}
+{%- assign description = description | replace: newline, ' ' | strip -%}
+- [{{ include.item.label }}]({{ site.url }}{{ item_url }}){% if description != '' %}: {{ description }}{% endif %}

--- a/_includes/llms_link.txt
+++ b/_includes/llms_link.txt
@@ -16,4 +16,8 @@
 {%- capture newline %}
 {% endcapture -%}
 {%- assign description = description | replace: newline, ' ' | strip -%}
-- [{{ include.item.label }}]({{ site.url }}{{ item_url }}){% if description != '' %}: {{ description }}{% endif %}
+{%- assign link_url = item_url -%}
+{%- if found_page.markdown_url -%}
+{%- assign link_url = found_page.markdown_url -%}
+{%- endif -%}
+- [{{ include.item.label }}]({{ site.url }}{{ link_url }}){% if description != '' %}: {{ description }}{% endif %}

--- a/_includes/sidebar_items.html
+++ b/_includes/sidebar_items.html
@@ -1,0 +1,12 @@
+<ul>
+  {%- for item in include.items %}
+  <li><a class="sidenav-link" data-sidenav href="{{ item.url }}">{{ item.label | escape }}</a></li>
+  {%- if item.children %}
+  <ul class="pl-[8%]">
+    {%- for child in item.children %}
+    <li><a class="sidenav-link--sub" data-sidenav href="{{ child.url }}">{{ child.label | escape }}</a></li>
+    {%- endfor %}
+  </ul>
+  {%- endif %}
+  {%- endfor %}
+</ul>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -129,109 +129,18 @@
             <pagefind-modal-trigger></pagefind-modal-trigger>
             <pagefind-modal></pagefind-modal>
           </div>
-          <h3 class="font-bold tracking-[0.04em] text-lg text-neutral-600 pb-2">Getting Started</h3>
-          <ul>
-            <li><a class="sidenav-link" data-sidenav href="/installation">Installation</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/rubygems-basics">RubyGems Basics</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/getting_started">Getting Started with Bundler</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/make-your-own-gem">Make your own gem</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/publishing">Publishing your gem</a></li>
-          </ul>
-
-          <h3 class="font-bold tracking-[0.04em] text-lg text-neutral-600 pt-5 pb-1">Guides</h3>
-          <h4 class="font-semibold tracking-[0.08em] uppercase text-xs text-neutral-500 pt-2 pb-1">Dependency Management</h4>
-          <ul>
-            <li><a class="sidenav-link" data-sidenav href="/using_bundler_in_applications">How to manage application dependencies with Bundler</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/dependency_management">How to manage dependencies with Bundler</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/updating_gems">How to update gems with Bundler</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/groups">How to manage groups of gems</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/git">How to install gems from git repositories</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/bundler_setup">How to use Bundler with Ruby</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/bundler_in_a_single_file_ruby_script">How to use Bundler in a single-file Ruby script</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/deploying">How to deploy bundled applications</a></li>
-          </ul>
-          <h4 class="font-semibold tracking-[0.08em] uppercase text-xs text-neutral-500 pt-3 pb-1">Gem Development</h4>
-          <ul>
-            <li><a class="sidenav-link" data-sidenav href="/name-your-gem">Name your gem</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/patterns">Patterns</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/gems-with-extensions">Gems with Extensions</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/rubygems">Bundler in gems</a></li>
-          </ul>
-          <h4 class="font-semibold tracking-[0.08em] uppercase text-xs text-neutral-500 pt-3 pb-1">Publishing &amp; Security</h4>
-          <ul>
-            <li><a class="sidenav-link" data-sidenav href="/trusted-publishing">Trusted Publishing</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/setting-up-multifactor-authentication">Setting up multi-factor authentication</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/using-mfa-in-command-line">Using multi-factor authentication in command line</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/managing-owners-using-ui">Managing owners using UI</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/organizations">Organizations</a></li>
-            <ul class="pl-[8%]">
-              <li><a class="sidenav-link--sub" data-sidenav href="/organizations/getting-started">Getting Started</a></li>
-              <li><a class="sidenav-link--sub" data-sidenav href="/organizations/managing-members">Managing Members</a></li>
-              <li><a class="sidenav-link--sub" data-sidenav href="/organizations/roles-and-permissions">Roles &amp; Permissions</a></li>
-              <li><a class="sidenav-link--sub" data-sidenav href="/organizations/transferring-gems">Transferring Gems</a></li>
-            </ul>
-            <li><a class="sidenav-link" data-sidenav href="/removing-a-published-gem">Removing a Published gem</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/security">Security Practices</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/cooldown">How to delay new gem versions with cooldown</a></li>
-          </ul>
-          <h4 class="font-semibold tracking-[0.08em] uppercase text-xs text-neutral-500 pt-3 pb-1">Integrations</h4>
-          <ul>
-            <li><a class="sidenav-link" data-sidenav href="/rails">How to use Bundler with Rails</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/sinatra">How to use Bundler with Sinatra</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/bundler_docker_guide">How to use Bundler with Docker</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/ci">How to use Bundler in CI</a></li>
-          </ul>
-          <h4 class="font-semibold tracking-[0.08em] uppercase text-xs text-neutral-500 pt-3 pb-1">Hosting &amp; Sources</h4>
-          <ul>
-            <li><a class="sidenav-link" data-sidenav href="/run-your-own-gem-server">Run your own gem server</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/using-s3-source">Using S3 as gem source</a></li>
-          </ul>
-          <h4 class="font-semibold tracking-[0.08em] uppercase text-xs text-neutral-500 pt-3 pb-1">Extending</h4>
-          <ul>
-            <li><a class="sidenav-link" data-sidenav href="/plugins">RubyGems Plugins</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/bundler_plugins">How to write a Bundler plugin</a></li>
-          </ul>
-          <h4 class="font-semibold tracking-[0.08em] uppercase text-xs text-neutral-500 pt-3 pb-1">Troubleshooting</h4>
-          <ul>
-            <li><a class="sidenav-link" data-sidenav href="/troubleshooting">Troubleshooting common issues</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/rubygems_tls_ssl_troubleshooting_guide">How to troubleshoot RubyGems and Bundler TLS/SSL Issues</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/git_bisect">How to use git bisect with Bundler</a></li>
-          </ul>
-
-          <h3 class="font-bold tracking-[0.04em] text-lg text-neutral-600 pt-5 pb-2">Concepts</h3>
-          <ul>
-            <li><a class="sidenav-link" data-sidenav href="/what-is-a-gem">What is a gem?</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/gemfile-and-gemspec">Gemfile and gemspec</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/gem-installation-and-loading">Where gems are installed and how they load</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/dependency-resolution">How dependency resolution works</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/gemfile-lock">How Gemfile.lock works</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/versioning">Versioning and compatibility</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/default-gems-and-bundled-gems">Default gems and bundled gems</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/cve">Common Vulnerabilities and Exposures</a></li>
-          </ul>
-
-          <h3 class="font-bold tracking-[0.04em] text-lg text-neutral-600 pt-5 pb-2">Reference</h3>
-          <ul>
-            <li><a class="sidenav-link" data-sidenav href="/command-reference">gem Command Reference</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/command-reference/bundle">Bundler Command Reference</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/gemfile">Gemfile Reference</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/gemfile_ruby">Ruby Directive</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/specification-reference">Specification Reference</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/rubygems-org-api">RubyGems.org API</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/rubygems-org-compact-index-api">RubyGems.org Compact Index API</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/rubygems-org-rate-limits">RubyGems.org rate limits</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/api-key-scopes">API key scopes</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/bundler-compatibility">Bundler compatibility with Ruby</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/bundler_known_plugins">Known Bundler Plugins</a></li>
-          </ul>
-
-          <h3 class="font-bold tracking-[0.04em] text-lg text-neutral-600 pt-5 pb-2">Appendix</h3>
-          <ul>
-            <li><a class="sidenav-link" data-sidenav href="/faqs">Frequently Asked Questions</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/resources">Resources</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/contributing">Contributing to RubyGems</a></li>
-            <li><a class="sidenav-link" data-sidenav href="/credits">Credits</a></li>
-          </ul>
+          {%- for section in site.data.sidebar %}
+          {%- if forloop.first %}{% assign h3_padding = "pb-2" %}{% elsif section.subsections %}{% assign h3_padding = "pt-5 pb-1" %}{% else %}{% assign h3_padding = "pt-5 pb-2" %}{% endif %}
+          <h3 class="font-bold tracking-[0.04em] text-lg text-neutral-600 {{ h3_padding }}">{{ section.title | escape }}</h3>
+          {%- if section.subsections %}
+          {%- for subsection in section.subsections %}
+          <h4 class="font-semibold tracking-[0.08em] uppercase text-xs text-neutral-500 {% if forloop.first %}pt-2{% else %}pt-3{% endif %} pb-1">{{ subsection.title | escape }}</h4>
+          {% include sidebar_items.html items=subsection.items %}
+          {%- endfor %}
+          {%- else %}
+          {% include sidebar_items.html items=section.items %}
+          {%- endif %}
+          {%- endfor %}
         </div>
 
         <div class="md:float-right md:w-[calc(100%-240px)] md:pl-[60px]" data-pagefind-body data-pagefind-meta="title:{{ page.title | escape }}">

--- a/_plugins/llms_full.rb
+++ b/_plugins/llms_full.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Concatenates the Markdown of every page listed in _data/sidebar.yml into
+# _site/llms-full.txt, the full-text companion to /llms.txt. Pages without a
+# Markdown alternate (the generated HTML man pages) are skipped.
+module LlmsFull
+  HEADER = <<~HEADER
+    # RubyGems Guides
+
+    > Everything about library management in Ruby: learn what gems are, how to use them in your projects, and how to build and publish your own.
+  HEADER
+
+  def self.each_item(sections, &block)
+    sections.each do |section|
+      (section["subsections"] || [section]).each do |subsection|
+        subsection["items"].each do |item|
+          block.call(item)
+          (item["children"] || []).each(&block)
+        end
+      end
+    end
+  end
+end
+
+Jekyll::Hooks.register :site, :post_write do |site|
+  chunks = [LlmsFull::HEADER]
+  LlmsFull.each_item(site.data["sidebar"]) do |item|
+    page = site.pages.find { |candidate| candidate.url.chomp("/") == item["url"] }
+    next unless page && page.data["markdown_url"]
+
+    chunks << <<~PAGE
+      # #{page.data["title"]}
+
+      Source: #{site.config["url"]}#{page.url}
+
+      #{MarkdownAlternates.markdown_for(site, page).strip}
+    PAGE
+  end
+  File.write(site.in_dest_dir("llms-full.txt"), chunks.join("\n---\n\n"))
+end

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,31 @@
+---
+permalink: /llms.txt
+layout: null
+---
+# RubyGems Guides
+
+> Everything about library management in Ruby: learn what gems are, how to use them in your projects, and how to build and publish your own.
+
+Ruby libraries are packaged and distributed as gems. RubyGems installs individual gems and provides the `gem` command, and Bundler tracks the exact set of gems an application depends on through a `Gemfile`. Both ship with Ruby. Gems are published and downloaded on [RubyGems.org](https://rubygems.org). These guides cover both tools and the RubyGems.org APIs.
+{% for section in site.data.sidebar -%}
+{%- if section.subsections -%}
+{%- for subsection in section.subsections %}
+## {{ subsection.title }}
+
+{% for item in subsection.items -%}
+{% include llms_link.txt item=item -%}
+{% if item.children -%}
+{% for child in item.children -%}
+{% include llms_link.txt item=child -%}
+{% endfor -%}
+{% endif -%}
+{% endfor -%}
+{% endfor -%}
+{%- else %}
+## {{ section.title }}
+
+{% for item in section.items -%}
+{% include llms_link.txt item=item -%}
+{% endfor -%}
+{%- endif -%}
+{% endfor -%}


### PR DESCRIPTION
guides.rubygems.org has no `llms.txt`, so LLM crawlers and agents get no machine-readable index of the site (flagged by the ruby.evilmartians.com discoverability scorecard). This adds `/llms.txt` in the [llmstxt.org](https://llmstxt.org/) format: an H1, a summary blockquote, and the full page list grouped by the sidebar sections, each link with a one-line description. It also adds `/llms-full.txt`, which concatenates the Markdown of every listed page in sidebar order via `MarkdownAlternates.markdown_for` from #524.

To keep the lists from drifting, I extracted the sidebar out of `_layouts/default.html` into `_data/sidebar.yml`; the sidebar and `llms.txt` render from the same data, so a page added to the sidebar appears in both files automatically. Links point at the Markdown alternates from #524 where they exist. The rendered site is unchanged apart from sidebar indentation, verified with a whitespace-insensitive diff of the full `_site` output against `main`. Descriptions come from each page's leading `<em>` summary, with fallbacks in the data file for pages that lack one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
