### PR TITLE
Protect ${{ matrix.ruby }} from Liquid evaluation in ci.md

### DIFF
--- a/ci.md
+++ b/ci.md
@@ -27,6 +27,7 @@ Use the [ruby/setup-ruby](https://github.com/ruby/setup-ruby) action. With `bund
 
 The `ruby-version` input can be omitted if the repository has a `.ruby-version`, `.tool-versions`, or `mise.toml` file. To test against several Ruby versions, use a matrix:
 
+{% raw %}
     jobs:
       test:
         strategy:
@@ -40,6 +41,7 @@ The `ruby-version` input can be omitted if the repository has a `.ruby-version`,
               ruby-version: ${{ matrix.ruby }}
               bundler-cache: true
           - run: bundle exec rake
+{% endraw %}
 
 To test against multiple Gemfiles, set `BUNDLE_GEMFILE` in a job-level `env` block (for example from a matrix value) so that both `setup-ruby` and later steps use the same Gemfile.
 


### PR DESCRIPTION
https://guides.rubygems.org/ci/ renders the matrix example as `ruby-version: $` because Jekyll evaluates `${{ matrix.ruby }}` as a Liquid expression. Wrapping the code block in `{% raw %}` preserves the expression in both the HTML page and the `/ci.md` alternate added by #524. Verified with a local `jekyll build`, and grep shows no other guide contains an unprotected `${{ }}`.