### PR TITLE
Add configuration and environment variables reference pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -221,6 +221,8 @@
             <li><a class="sidenav-link" data-sidenav href="/rubygems-org-rate-limits">RubyGems.org rate limits</a></li>
             <li><a class="sidenav-link" data-sidenav href="/api-key-scopes">API key scopes</a></li>
             <li><a class="sidenav-link" data-sidenav href="/bundler-compatibility">Bundler compatibility with Ruby</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/configuration">Configuration (.gemrc)</a></li>
+            <li><a class="sidenav-link" data-sidenav href="/environment-variables">Environment variables</a></li>
             <li><a class="sidenav-link" data-sidenav href="/bundler_known_plugins">Known Bundler Plugins</a></li>
           </ul>
 

--- a/bundler-compatibility.md
+++ b/bundler-compatibility.md
@@ -4,7 +4,7 @@ title: Bundler compatibility with Ruby
 description: Ruby and RubyGems requirements needed for Bundler compatibility
 url: /bundler-compatibility
 previous: /api-key-scopes
-next: /bundler_known_plugins
+next: /configuration
 ---
 ## Bundler compatibility with Ruby & RubyGems
 

--- a/bundler_known_plugins.md
+++ b/bundler_known_plugins.md
@@ -2,7 +2,7 @@
 layout: default
 title: Known Plugins
 url: /bundler_known_plugins
-previous: /bundler-compatibility
+previous: /environment-variables
 next: /faqs
 ---
 

--- a/configuration.md
+++ b/configuration.md
@@ -1,0 +1,66 @@
+---
+layout: default
+title: Configuration (.gemrc)
+description: Where the gem command reads its configuration and the options a .gemrc file accepts
+url: /configuration
+previous: /bundler-compatibility
+next: /environment-variables
+---
+
+<em class="text-neutral-600">Where the `gem` command reads its configuration, and the options a `.gemrc` file accepts.</em>
+
+The `gem` command works fine with no configuration at all. A gemrc file exists to change defaults you would otherwise repeat on every invocation, such as disabling documentation generation or adding a private gem server.
+
+## Files and precedence
+
+RubyGems merges configuration from several places. Later entries override earlier ones:
+
+1. Defaults set by the operating system packager and the Ruby implementation.
+2. The system-wide file, `gemrc` in the system configuration directory, typically `/etc/gemrc`.
+3. The user file, `~/.gemrc`. When that file does not exist, RubyGems reads `$XDG_CONFIG_HOME/gem/gemrc` instead, which is usually `~/.config/gem/gemrc`.
+4. Files listed in the `GEMRC` environment variable, separated by `:` on Unix and `;` on Windows.
+
+`gem --config-file FILE` reads a specific file in place of the user file, and `gem --norc` ignores gemrc files entirely.
+
+## Format
+
+A gemrc file is a YAML hash with two kinds of keys. Symbol keys, written with a leading colon, set RubyGems options. String keys naming a gem command set default command-line arguments for that command, and the special key `gem` sets default arguments for every command.
+
+```yaml
+:sources:
+- https://rubygems.org/
+:backtrace: true
+:concurrent_downloads: 16
+install: --no-document
+update: --no-document
+```
+
+With this file, `gem install rails` behaves as if you had typed `gem install rails --no-document`. Arguments given on the command line are appended after the defaults.
+
+## Options
+
+These are the symbol keys RubyGems understands, with their built-in defaults.
+
+| Key | Description |
+|-----|-------------|
+| `:sources` | Array of gem server URLs that gems are installed from. Default: `https://rubygems.org/`. |
+| `:backtrace` | Print a full backtrace when the gem command hits an error. Default: `true`. |
+| `:verbose` | Output level. `false` is quiet, `true` is normal, and any other value such as `:really` enables extra output. Default: `true`. |
+| `:update_sources` | Update repository metadata automatically. Default: `true`. |
+| `:concurrent_downloads` | Number of gem downloads performed in parallel. Default: `8`. |
+| `:cert_expiration_length_days` | Validity period, in days, of certificates created or re-signed by `gem cert`. Default: `365`. |
+| `:install_extension_in_lib` | Install built extensions into the gem's `lib` directory as well as the extension directory. Default: `true`. |
+| `:ipv4_fallback_enabled` | Experimental. Fall back to IPv4 when IPv6 is unreachable or slow. Default: `false`. |
+| `:global_gem_cache` | Cache downloaded `.gem` files in one directory shared across all Ruby installations, `~/.cache/gem/gems` by default. Default: `false`. |
+| `:use_psych` | Parse gemrc and other RubyGems YAML files with Psych instead of the built-in minimal YAML parser. Default: `false`. |
+| `:prevent_update_suggestion` | Never suggest running `gem update --system` when a newer RubyGems is available. |
+| `:disable_default_gem_server` | Require an explicit `--host` when pushing gems instead of defaulting to RubyGems.org. |
+| `:gemhome` | The directory gems are installed into. More commonly set with the `GEM_HOME` environment variable. |
+| `:gempath` | Array of directories searched for installed gems. More commonly set with the `GEM_PATH` environment variable. |
+| `:ssl_verify_mode` | OpenSSL verification mode for HTTPS connections to gem servers. |
+| `:ssl_ca_cert` | Path to a CA certificate file or directory used for HTTPS connections. |
+| `:ssl_client_cert` | Path to a client certificate used for HTTPS connections that require client authentication. |
+
+API keys for pushing gems are not stored in gemrc. They live in a separate credentials file, `~/.gem/credentials`. See [API key scopes](/api-key-scopes) for how keys are created and scoped.
+
+Bundler is configured separately through `bundle config`, and its settings do not come from gemrc. See [bundle config](/command-reference/bundle-config/).

--- a/environment-variables.md
+++ b/environment-variables.md
@@ -1,0 +1,55 @@
+---
+layout: default
+title: Environment variables
+description: Environment variables that the gem command and the RubyGems runtime read
+url: /environment-variables
+previous: /configuration
+next: /bundler_known_plugins
+---
+
+<em class="text-neutral-600">The environment variables the `gem` command and the RubyGems runtime respond to.</em>
+
+None of these are required. They override defaults per shell or per process, which makes them useful in CI, in version manager hooks, and for one-off experiments. Persistent preferences belong in a gemrc file instead. See [Configuration](/configuration).
+
+## Paths
+
+| Variable | Description |
+|----------|-------------|
+| `GEM_HOME` | The directory gems are installed into. See [Where gems are installed and how they load](/gem-installation-and-loading). |
+| `GEM_PATH` | Directories searched for installed gems, separated by `:` on Unix and `;` on Windows. |
+| `GEM_SPEC_CACHE` | The directory where gem specifications fetched from remote sources are cached. Defaults to `~/.gem/specs`, or to `$XDG_CACHE_HOME/gem/specs` when `~/.gem/specs` does not exist. |
+| `GEMRC` | Additional gemrc files to read, separated by `:` on Unix and `;` on Windows. See [Configuration](/configuration). |
+
+## Loading gems
+
+| Variable | Description |
+|----------|-------------|
+| `RUBYGEMS_GEMDEPS` | Path to a gem dependencies file (`Gemfile`, `gem.deps.rb`, or `Isolate`) whose gems RubyGems activates automatically at startup. The special value `-` searches the current directory and its parents for one. Automatic discovery can execute code from a directory you do not control, so avoid `-` on multiuser systems. |
+| `GEM_REQUIREMENT_<NAME>` | A version requirement applied when RubyGems activates the gem `<NAME>`, uppercased. For example, `GEM_REQUIREMENT_BUNDLER="~> 2.7"` restricts which Bundler version is activated. |
+
+## Building and pushing gems
+
+| Variable | Description |
+|----------|-------------|
+| `SOURCE_DATE_EPOCH` | A Unix timestamp used instead of the current time when packaging a gem, so that building the same input twice produces byte-identical `.gem` files. |
+| `RUBYGEMS_HOST` | The gem server that `gem push` sends gems to when no `--host` is given. |
+| `GEM_HOST_API_KEY` | An API key used to authenticate against the gem server instead of the key stored in `~/.gem/credentials`. |
+| `GEM_HOST_OTP_CODE` | A one-time password for pushing when the account has multi-factor authentication enabled. Equivalent to `--otp`. |
+| `GEM_PRIVATE_KEY_PASSPHRASE` | The passphrase of the private signing key, read by `gem cert` and when building signed gems instead of prompting for it. |
+
+## Network
+
+| Variable | Description |
+|----------|-------------|
+| `HTTP_PROXY`, `HTTP_PROXY_USER`, `HTTP_PROXY_PASS` | The proxy server, and credentials for it, used for connections to gem servers. |
+| `NO_PROXY` | Hosts that are connected to directly, bypassing the proxy. |
+
+## Other
+
+| Variable | Description |
+|----------|-------------|
+| `RUBYGEMS_PREVENT_UPDATE_SUGGESTION` | When set, the gem command never suggests running `gem update --system` after noticing a newer RubyGems release. |
+
+## Bundler
+
+Bundler variables are not listed here. Every setting understood by `bundle config` can also be set through a corresponding `BUNDLE_*` environment variable, for example `BUNDLE_PATH` or `BUNDLE_WITHOUT`. See [bundle config](/command-reference/bundle-config/).

--- a/gem-installation-and-loading.md
+++ b/gem-installation-and-loading.md
@@ -30,7 +30,7 @@ Where gems are installed
 
 The installation directory, often called the gem home, is where `gem install` puts gems. Inside it, each gem version gets its own directory under `gems/`, such as `gems/rake-13.4.2/`, with metadata under `specifications/` and compiled extensions under `extensions/`. Because every version has its own directory, any number of versions of the same gem can be installed side by side.
 
-The gem home belongs to one Ruby installation. It normally lives inside the Ruby installation itself, and its path includes the Ruby ABI version, `4.0.0` above, because gems with compiled extensions only work with the Ruby they were built for. The `GEM_HOME` environment variable overrides where gems are installed, and `GEM_PATH` overrides the list of directories searched when loading them. You rarely need to set either by hand. In scripts, `gem env gemdir` and `gem env gempath` print the values directly.
+The gem home belongs to one Ruby installation. It normally lives inside the Ruby installation itself, and its path includes the Ruby ABI version, `4.0.0` above, because gems with compiled extensions only work with the Ruby they were built for. The `GEM_HOME` environment variable overrides where gems are installed, and `GEM_PATH` overrides the list of directories searched when loading them. You rarely need to set either by hand. In scripts, `gem env gemdir` and `gem env gempath` print the values directly. These and the other variables RubyGems reads are listed in [Environment variables](/environment-variables).
 
 Installing without root permission
 ----------------------------------


### PR DESCRIPTION
The guides say nothing about `.gemrc` or the environment variables RubyGems reads, while uv and cargo both ship reference pages for settings and environment variables. This adds two pages to the Reference section. `/configuration` covers where `gem` reads gemrc files and their merge order, the YAML format including per-command default arguments, and the symbol keys defined in `lib/rubygems/config_file.rb` with their defaults. `/environment-variables` lists the variables verified against `lib/rubygems`, from `GEM_HOME` and `GEM_SPEC_CACHE` to `RUBYGEMS_GEMDEPS` and `SOURCE_DATE_EPOCH`, and delegates `BUNDLE_*` to the `bundle config` page. Both pages join the sidebar and the previous/next loop after Bundler compatibility.

Generated with [Claude Code](https://claude.com/claude-code)
