### PR TITLE
Refresh Bundler compatibility page

### DIFF
--- a/bundler-compatibility.md
+++ b/bundler-compatibility.md
@@ -8,27 +8,19 @@ next: /bundler_known_plugins
 ---
 ## Bundler compatibility with Ruby & RubyGems
 
-The latest Bundler release should always support, at the very least, all
-rubies that have not yet reached their End of Life date.
+Bundler and RubyGems are developed in the same repository, [ruby/rubygems](https://github.com/ruby/rubygems), and every release ships them as a matching pair. Starting with the 4.0 series they share the same version number. Each Ruby release also bundles a matching pair, for example Ruby 4.0 ships RubyGems 4.0 and Bundler 4.0.
 
-The latest Bundler release should always support all RubyGems versions higher
-than or equal to the one shipped with the oldest Ruby version supported.
-RubyGems is not allowed to be downgraded further than that, so upgrading or
-downgrading RubyGems should not affect Bundler.
+The latest Bundler release supports, at the very least, all Ruby versions that have not yet reached their End of Life date. Its minimum RubyGems version is the RubyGems that shipped with the oldest supported Ruby. RubyGems cannot be downgraded below the version a Ruby shipped with, so any supported Ruby satisfies both requirements out of the box.
 
-That effectively comes down to the following:
+The currently supported and recent Bundler series require:
 
-* Bundler **4.0** or higher
-  * requires a minimum ruby version of **3.2.0**, and a minimum RubyGems version of **3.4.1** (version of RubyGems shipped with ruby **3.2.0**).
-* Bundler **2.7**
-  * requires a minimum ruby version of **3.2.0**, and a minimum RubyGems version of **3.4.1** (version of RubyGems shipped with ruby **3.2.0**).
-* Bundler **2.6**
-  * requires a minimum ruby version of **3.1.0**, and a minimum RubyGems version of **3.3.3** (version of RubyGems shipped with ruby **3.1.0**).
-* Bundler **2.5**
-  * requires a minimum ruby version of **3.0.0**, and a minimum RubyGems version of **3.2.3** (version of RubyGems shipped with ruby **3.0.0**).
-* Bundler **2.4**
-  * requires a minimum ruby version of **2.6.0**, and a minimum RubyGems version of **3.0.1** (version of RubyGems shipped with ruby **2.6.0**).
-* Bundler **2.0** through **2.3**
-  * requires a minimum ruby version of **2.3.0**, and a minimum RubyGems version of **2.5** (version of RubyGems shipped with ruby **2.3.0**).
-* Bundler **1**
-  * requires a minimum Ruby version of **1.8.7**, and a minimum RubyGems version of **1.3.6** (version of RubyGems shipped with ruby **1.8.7**).
+| Bundler | Ruby | RubyGems |
+| ------- | ---- | -------- |
+| 4.0 | >= 3.2.0 | >= 3.4.1 |
+| 2.7 | >= 3.2.0 | >= 3.4.1 |
+| 2.6 | >= 3.1.0 | >= 3.3.3 |
+| 2.5 | >= 3.0.0 | >= 3.2.3 |
+
+Older series have reached their End of Life. If you need the exact requirements of an old release, check its version page on [rubygems.org](https://rubygems.org/gems/bundler), which lists the required Ruby and RubyGems versions.
+
+In practice you rarely choose a Bundler version by hand. A project's `Gemfile.lock` records the version that created it under `BUNDLED WITH`, and Bundler automatically switches to that version when you run it. See [Installing Bundler](/installation) for details.


### PR DESCRIPTION
The `/bundler-compatibility` page still centered on EOL Bundler series down to 1.x. The table now covers only supported and recent series, with requirements verified against `bundler.gemspec` at each release tag and rubygems.org metadata. The page also explains that Bundler and RubyGems are released as a pair from `ruby/rubygems` sharing a version number since 4.0, and that `BUNDLED WITH` in `Gemfile.lock` selects the Bundler version automatically, linking to `/installation`. Sidebar and prev/next chain are unchanged.
