### PR TITLE
Document content-addressable native gems

### DIFF
--- a/caching-and-vendoring.md
+++ b/caching-and-vendoring.md
@@ -66,6 +66,8 @@ With a populated `vendor/cache`, or with the needed versions already in the gem 
 
 There is one caveat. During a normal install Bundler checks RubyGems.org for a [precompiled variant](/platforms) matching your platform even when every gem is cached. `--local` skips that check, so it only picks from the gems the cache actually contains. Building the cache with `--all-platforms` on a machine of the deployment platform avoids surprises here.
 
+For content-addressable native gems, `bundle install --local` installs the `.gem` file named with the content address from `vendor/cache`, preserves its content address and real platform metadata, and does not create a platform-named duplicate.
+
 Plain RubyGems can install from a local `.gem` file directly, either by path or by name with `--local` in a directory containing the file:
 
     $ gem install --local ./rake-13.4.2.gem

--- a/command-reference.md
+++ b/command-reference.md
@@ -57,10 +57,10 @@ Build a gem from a gemspec
 ### Options
 
 * `--platform PLATFORM`         - Specify the platform of gem to build
+* `--ruby-abi RUBY_ABI`         - Specify Ruby ABI X.Y. With a non-default platform, builds a content-addressable native gem
 * `--force`                     - skip validation of the spec
 * `--strict`                    - consider warnings as errors when validating the spec
 * `-o, --output FILE`               - output gem with the given filename
-* `--ruby-abi RUBY_ABI`         - Specify the Ruby ABI of gem to build (builds a content addressable gem)
 
 ### Common Options
 
@@ -98,9 +98,56 @@ Gems can be saved to a specified filename with the output option:
 
     $ gem build my_gem-1.0.gemspec --output=release.gem
 
-Platform gems can be built for a single Ruby ABI with the --ruby-abi option:
+A content-addressable native gem has a filename that includes a shortened
+lowercase hex SHA-256 checksum calculated from the `.gem` file contents. The
+content address is 8 to 64 characters long. The filename identifies the file by
+its contents; the platform and Ruby ABI come from gem metadata.
 
-    $ gem build my_gem-1.0.gemspec --ruby-abi=3.4
+Native gems can be built as source gems, multi-ABI platform gems, or
+content-addressable native gems:
+
+    $ gem build mygem.gemspec
+    Successfully built RubyGem
+    Name: mygem
+    Version: 1.0.0
+    File: mygem-1.0.0.gem
+
+    $ gem build mygem.gemspec --platform x86_64-linux
+    Successfully built RubyGem
+    Name: mygem
+    Version: 1.0.0
+    File: mygem-1.0.0-x86_64-linux.gem
+
+    $ gem build mygem.gemspec --platform x86_64-linux --ruby-abi 3.4
+    Successfully built RubyGem
+    Name: mygem
+    Version: 1.0.0
+    Platform: x86_64-linux
+    Ruby ABI: 3.4
+    File: mygem-1.0.0-78be552b.gem
+
+`--ruby-abi` creates a content-addressable gem because it is used for native
+gems whose packaged extension files are specific to one Ruby ABI. Traditional
+gem filenames identify only name, version, and platform, so they cannot
+distinguish separate Ruby-ABI-specific builds for the same platform. RubyGems
+therefore uses a content address in the filename and stores the real platform
+and Ruby ABI in the gem metadata.
+
+The `--ruby-abi` value must be in `X.Y` form, such as `3.4`, and the gem must
+be platform-specific, either from the gemspec or from `--platform`. RubyGems
+records the ABI by setting `required_ruby_version` to `~> X.Y.0`, raises
+`required_rubygems_version` to at least `>= 4.1.0.a`, and rejects `--output`
+because the filename must be derived from the gem contents. These fail:
+
+    $ gem build mygem.gemspec --platform x86_64-linux --ruby-abi invalid
+    $ gem build mygem.gemspec --platform x86_64-linux --ruby-abi 3.4.1
+    $ gem build mygem.gemspec --ruby-abi 3.4
+    $ gem build mygem.gemspec --platform x86_64-linux --ruby-abi 3.4 --output release.gem
+
+Builds for the same name, version, and platform but different Ruby ABIs produce
+different content-addressable filenames. If the gemspec already has
+`required_ruby_version`, it must be compatible with the requested ABI.
+Otherwise the build fails instead of creating misleading ABI metadata.
 
 ## gem cert
 
@@ -340,6 +387,11 @@ the named gem).
 The dependency list can be displayed in a format suitable for piping for
 use with other commands.
 
+Remote dependency output understands content-addressable (for example,
+`mygem-1.0.0-78be552b.gem`) native gems. RubyGems displays and matches the
+platform and Ruby ABI from gem metadata instead of treating the SHA suffix as a
+platform.
+
 ## gem environment
 
 Display information about the RubyGems environment
@@ -508,6 +560,12 @@ unpacked to examine their contents.
 See the build command help for an example of unpacking a gem, modifying it,
 then repackaging it.
 
+When the selected remote candidate is a content-addressable native gem, fetch
+writes the `.gem` file named with the content address:
+
+    $ gem fetch mygem
+    Downloaded mygem-1.0.0-78be552b.gem
+
 ## gem generate_index
 
 Generates the index files for a gem server directory (requires rubygems-generate_index)
@@ -601,6 +659,18 @@ Show information for the given gem
 
 Info prints information about the gem such as name, description, website, license and installed paths
 
+For remote content-addressable (for example, `mygem-1.0.0-a1b2c3d4.gem`) native
+gems, info displays the platform and Ruby ABI instead of the content-address
+suffix:
+
+    $ gem info mygem -r
+
+    *** REMOTE GEMS ***
+
+    mygem (1.0.0)
+        Platforms:
+            x86_64-linux Ruby ABI: 3.3, 3.4
+
 ## gem install
 
 Install a gem into the local repository
@@ -679,6 +749,21 @@ Install a gem into the local repository
 ### Description
 
 The install command installs local or remote gem into a gem repository.
+
+Local content-addressable native gems use `.gem` files named with the content
+address, such as `mygem-1.0.0-78be552b.gem`:
+
+    $ gem install ./mygem-1.0.0-78be552b.gem --local
+
+RubyGems validates the content-address suffix against the file SHA-256, installs
+under the name-version-SHA identity, and preserves the platform metadata.
+Reinstalling the same file is idempotent. A content-address mismatch fails.
+
+For remote installs, RubyGems prefers compatible candidates in this order:
+
+1. content-addressable native gem
+2. multi-ABI platform gem
+3. source gem
 
 For gems with executables ruby installs a wrapper file into the executable
 directory by default.  This can be overridden with the --no-wrappers option.
@@ -808,6 +893,16 @@ The --details option displays additional details including the summary, the
 homepage, the author, the locations of different versions of the gem.
 
 To search for remote gems use the search command.
+
+For remote content-addressable native gems, list displays the platform and Ruby
+ABI instead of the content-address suffix:
+
+    $ gem list mygem -r
+    mygem (1.0.0 Platform: x86_64-linux, Ruby ABI: 3.4)
+
+Multiple Ruby ABIs for the same platform are grouped:
+
+    mygem (1.0.0 Platform: x86_64-linux, Ruby ABI: 3.3, 3.4)
 
 ## gem lock
 
@@ -971,6 +1066,9 @@ The outdated command lists gems you may wish to upgrade to a newer version.
 You can check for dependency mismatches using the dependency command and
 update the gems with the update or install commands.
 
+Outdated checks understand content-addressable native gems and do not treat the
+SHA suffix as a platform.
+
 ## gem owner
 
 Manage gem owners of a gem on the push server
@@ -1089,10 +1187,10 @@ Push a gem up to the gem server
 ### Options
 
 * `-k, --key KEYNAME`               - Use the given API key from ~/.local/share/gem/credentials
+* `--platform PLATFORM`         - Platform selector for choosing one gem from multiple files
+* `--ruby-abi RUBY_ABI`         - Ruby ABI X.Y selector for choosing one gem from multiple files
 * `--otp CODE`                  - Digit code for multifactor authentication You can also use the environment variable GEM_HOST_OTP_CODE
 * `--host HOST`                 - Push to another gemcutter-compatible host (e.g. https://rubygems.org)
-* `--platform PLATFORM`         - Push a gem for a specific platform (e.g. x86_64-darwin-20)
-* `--ruby-abi RUBY_ABI`         - Specify the Ruby ABI of gem to push (e.g. 3.4)
 * `--attestation FILE`          - Push with sigstore attestations (FILE must be a JSON sigstore bundle)
 
 ### Local/Remote Options
@@ -1125,6 +1223,26 @@ command.  For further discussion see the help for the yank command.
 The push command will use ~/.gem/credentials to authenticate to a server, but you can use the RubyGems environment variable GEM_HOST_API_KEY to set the api key to authenticate. If the :credential_store: gemrc option (or RUBYGEMS_CREDENTIAL_STORE environment variable) is set, the API key is stored in and read from the credential store it selects instead of ~/.gem/credentials.
 
 The API key to send is resolved in this order: the GEM_HOST_API_KEY environment variable, the --key option, the host's own key in the credential store (when :credential_store: is set), the host's own key in ~/.gem/credentials, then the default RubyGems.org key from either place. The first one found is used.
+
+Pushing an exact file is unchanged, including content-addressable native gems:
+
+    $ gem push mygem-1.0.0.gem
+    $ gem push mygem-1.0.0-x86_64-linux.gem
+    $ gem push mygem-1.0.0-78be552b.gem
+
+When multiple candidate files are given, use the `--platform` and `--ruby-abi`
+selectors to push exactly one gem. RubyGems reads each candidate gemspec and
+matches the requested platform and/or Ruby ABI:
+
+    $ gem push mygem-1.0.0-*.gem --platform x86_64-linux --ruby-abi 3.4
+    $ gem push mygem-1.0.0-*.gem --platform x86_64-linux
+    $ gem push mygem-1.0.0-*.gem --ruby-abi 3.4
+
+If exactly one file matches, it is pushed. If no file matches, the command fails
+with an error. If multiple files match, the command fails as ambiguous. Multiple
+files without selectors are still rejected:
+
+    $ gem push mygem-1.0.0-*.gem
 
 ## gem rdoc
 
@@ -1274,6 +1392,16 @@ take a little longer to complete as it must download the information
 individually from the index.
 
 To list local gems use the list command.
+
+For remote content-addressable native gems, search displays the platform and
+Ruby ABI instead of the content-address suffix:
+
+    $ gem search mygem -r
+    mygem (1.0.0 Platform: x86_64-linux, Ruby ABI: 3.4)
+
+Multiple Ruby ABIs for the same platform are grouped:
+
+    mygem (1.0.0 Platform: x86_64-linux, Ruby ABI: 3.3, 3.4)
 
 ## gem server
 
@@ -1699,6 +1827,10 @@ The update command will update your gems to the latest version.
 The update command does not remove the previous version. Use the cleanup
 command to remove old versions.
 
+Updates understand content-addressable native gems. RubyGems can update to a
+compatible content-addressable native gem and does not treat the SHA suffix as
+a platform.
+
 ## gem which
 
 Find the location of a library file you can require
@@ -1747,8 +1879,8 @@ Remove a pushed gem from the index
 ### Options
 
 * `-v, --version VERSION`           - Specify version of gem to remove
-* `--platform PLATFORM`         - Specify the platform of gem to remove
-* `--ruby-abi RUBY_ABI`         - Specify the Ruby ABI of gem to remove
+* `--platform PLATFORM`         - Platform selector for the gem to remove
+* `--ruby-abi RUBY_ABI`         - Ruby ABI X.Y selector for the content-addressable variant
 * `--otp CODE`                  - Digit code for multifactor authentication You can also use the environment variable GEM_HOST_OTP_CODE
 * `--host HOST`                 - Yank from another gemcutter-compatible host (e.g. https://rubygems.org)
 * `-k, --key KEYNAME`               - Use the given API key from ~/.local/share/gem/credentials
@@ -1775,3 +1907,18 @@ The yank command permanently removes a gem you pushed to a server.
 Once you have pushed a gem several downloads will happen automatically
 via the webhooks. If you accidentally pushed passwords or other sensitive
 data you will need to change them immediately and yank your gem.
+
+Yanking by version or by version and platform is as follows:
+
+    $ gem yank mygem -v 1.0.0
+    $ gem yank mygem -v 1.0.0 --platform x86_64-linux
+
+Use `--ruby-abi` with `--platform` to yank one content-addressable variant:
+
+    $ gem yank mygem -v 1.0.0 --platform x86_64-linux --ruby-abi 3.4
+
+If no matching ABI exists, the command fails. Ruby ABI without platform also
+fails because Ruby ABI variants are platform-specific:
+
+    $ gem yank mygem -v 1.0.0 --platform x86_64-linux --ruby-abi 3.9
+    $ gem yank mygem -v 1.0.0 --ruby-abi 3.4

--- a/command-reference/bundle-install.html
+++ b/command-reference/bundle-install.html
@@ -57,6 +57,46 @@ that you did not update, but will re-resolve the dependencies of
 gems that you did update. You can find more information about this
 update process below under <a href="#CONSERVATIVE-UPDATING" title="CONSERVATIVE UPDATING" data-bare-link="true">CONSERVATIVE UPDATING</a>.</p>
 
+<h2 id="CONTENT-ADDRESSABLE-NATIVE-GEMS">Content-addressable native gems</h2>
+
+<p>A content-addressable native gem has a filename that includes a shortened
+SHA-256 checksum calculated from the <code>.gem</code> file contents, such as
+<code>mygem-1.0.0-a56253e0.gem</code>. The filename identifies the file by its contents;
+the platform and Ruby ABI come from gem metadata.</p>
+
+<p>A source gem contains source code and builds native extensions during install.
+A multi-ABI platform gem contains prebuilt native files for a platform, such as
+<code>x86_64-linux</code>, and may support more than one Ruby ABI. A content-addressable
+native gem contains prebuilt native files for one platform and one Ruby ABI,
+and uses the content address in the filename.</p>
+
+<p>Bundler selects any compatible content-addressable gem before falling back to a
+compatible multi-ABI platform gem and then to the source gem. Compatible means
+that the gem matches the install platform and Ruby ABI. A content-addressable
+gem may be preferred even when a multi-ABI platform gem offers a more specific
+platform target, such as <code>arm-darwin-23</code> instead of <code>arm-darwin</code>. The
+installed gem can still be required normally.</p>
+
+<p>Bundler records in the lockfile the multi-ABI platform gem in <code>GEM</code> and
+<code>CHECKSUMS</code>, and records the content-addressable file separately:</p>
+
+<pre><code>GEM
+  remote: https://rubygems.org/
+  specs:
+    mygem (1.0.0-x86_64-linux)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  mygem
+
+CONTENT ADDRESSES
+  mygem (1.0.0-x86_64-linux) a56253e0 sha256=&lt;content-addressable gem sha&gt;
+
+CHECKSUMS
+  mygem (1.0.0-x86_64-linux) sha256=&lt;platform gem sha&gt;</code></pre>
+
 <h2 id="OPTIONS">Options</h2>
 
 <dl>
@@ -71,7 +111,7 @@ Bundler config, Gemfile per-source settings, and the gemrc file.</dd>
 </dt>
 <dd>Force reinstalling every gem, even if already installed.</dd>
 <dt><code>--full-index</code></dt>
-<dd>Bundler will not call Rubygems' API endpoint (default) but download and cache
+<dd>Bundler will not call RubyGems' API endpoint (default) but download and cache
 a (currently big) index file of all gems. Performance can be improved for
 large bundles that seldom change by enabling this option.</dd>
 <dt><code>--gemfile=GEMFILE</code></dt>
@@ -87,14 +127,14 @@ to this location.</dd>
 number of available processors.</dd>
 <dt><code>--local</code></dt>
 <dd>Do not attempt to connect to <code>rubygems.org</code>. Instead, Bundler will use the
-gems already present in Rubygems' cache or in <code>vendor/cache</code>. Note that if an
+gems already present in RubyGems' cache or in <code>vendor/cache</code>. Note that if an
 appropriate platform-specific gem exists on <code>rubygems.org</code> it will not be
 found.</dd>
 <dt><code>--lockfile=LOCKFILE</code></dt>
 <dd>The location of the lockfile which Bundler should use. This defaults
 to the Gemfile location with <code>.lock</code> appended.</dd>
 <dt><code>--prefer-local</code></dt>
-<dd>Force using locally installed gems, or gems already present in Rubygems' cache
+<dd>Force using locally installed gems, or gems already present in RubyGems' cache
 or in <code>vendor/cache</code>, when resolving, even if newer versions are available
 remotely. Only attempt to connect to <code>rubygems.org</code> for gems that are not
 present locally.</dd>
@@ -116,15 +156,15 @@ See <span class="man-ref">gemfile<span class="s">(5)</span></span> for more info
 <dt><code>--retry=[&lt;number&gt;]</code></dt>
 <dd>Retry failed network or git requests for <var>number</var> times.</dd>
 <dt><code>--standalone[=&lt;list&gt;]</code></dt>
-<dd>Makes a bundle that can work without depending on Rubygems or Bundler at
+<dd>Makes a bundle that can work without depending on RubyGems or Bundler at
 runtime. A space separated list of groups to install can be specified.
 Bundler creates a directory named <code>bundle</code> and installs the bundle there. It
 also generates a <code>bundle/bundler/setup.rb</code> file to replace Bundler's own setup
 in the manner required.</dd>
 <dt><code>--trust-policy=TRUST-POLICY</code></dt>
-<dd>Apply the Rubygems security policy <var>policy</var>, where policy is one of
+<dd>Apply the RubyGems security policy <var>policy</var>, where policy is one of
 <code>HighSecurity</code>, <code>MediumSecurity</code>, <code>LowSecurity</code>, <code>AlmostNoSecurity</code>, or
-<code>NoSecurity</code>. For more details, please see the Rubygems signing documentation
+<code>NoSecurity</code>. For more details, please see the RubyGems signing documentation
 linked below in <a href="#SEE-ALSO" title="SEE ALSO" data-bare-link="true">SEE ALSO</a>.</dd>
 <dt><code>--target-rbconfig=TARGET-RBCONFIG</code></dt>
 <dd>Path to rbconfig.rb for the deployment target platform.</dd>
@@ -337,7 +377,7 @@ does not work, run <a href="/command-reference/bundle-update/">bundle update(1)<
 
 <ul>
   <li><a href="https://guides.rubygems.org/rubygems-basics/#installing-gems">Gem install docs</a></li>
-  <li><a href="https://guides.rubygems.org/security/">Rubygems signing docs</a></li>
+  <li><a href="https://guides.rubygems.org/security/">RubyGems signing docs</a></li>
 </ul>
 
   

--- a/gemfile-lock.md
+++ b/gemfile-lock.md
@@ -100,6 +100,25 @@ These are the direct dependencies, one line per `gem` call in the Gemfile. Anyth
 
 Each checksum is the SHA-256 digest of the packaged `.gem` file, and Bundler verifies every gem against it during installation. A gem that was tampered with after the lockfile was written fails to install, which protects deploys against a compromised gem source. Gems from git and path sources have no packaged file to digest, so their entries carry no checksum. Bundler writes this section into new lockfiles by default. To add it to an existing lockfile, see [Lockfile checksums](/security#lockfile-checksums).
 
+For content-addressable native gems, such as `mygem-1.0.0-78be552b.gem`, Bundler records the multi-ABI platform gem in `GEM` and `CHECKSUMS`, and records the content-addressable file separately:
+
+    GEM
+      remote: https://rubygems.org/
+      specs:
+        mygem (1.0.0-x86_64-linux)
+
+    PLATFORMS
+      x86_64-linux
+
+    DEPENDENCIES
+      mygem
+
+    CONTENT ADDRESSES
+      mygem (1.0.0-x86_64-linux) a56253e0 sha256=<content-addressable gem sha>
+
+    CHECKSUMS
+      mygem (1.0.0-x86_64-linux) sha256=<platform gem sha>
+
 ### RUBY VERSION
 
     RUBY VERSION

--- a/rubygems-org-api.md
+++ b/rubygems-org-api.md
@@ -84,6 +84,7 @@ Returns some basic information about the given gem. See below an example respons
       "version_created_at": "2026-07-29T15:02:41.060Z",
       "version_downloads": 78333,
       "platform": "ruby",
+      "ruby_abi": null,
       "authors": "David Heinemeier Hansson",
       "info": "Ruby on Rails is a full-stack web framework optimized for programmer happiness and sustainable productivity.",
       "licenses": ["MIT"],
@@ -126,6 +127,12 @@ Returns some basic information about the given gem. See below an example respons
       }
     }
 
+A content-addressable native gem has a filename that includes a shortened
+checksum calculated from the `.gem` file contents. API responses report the
+`platform` and may include `ruby_abi`, for example `"3.4"`. The `.gem` URL may
+use the content-addressable filename, such as `mygem-1.0.0-78be552b.gem`. The
+platform cannot be determined from the filename suffix.
+
 ### GET - `/api/v1/search.(json|yaml)?query=[YOUR QUERY]`
 
 Submit a search to RubyGems.org for active gems, just like a search query on the
@@ -161,6 +168,8 @@ of gems you own.
 ### POST - `/api/v1/gems`
 
 Submit a gem to RubyGems.org. Must post a built RubyGem in the request body.
+Content-addressable native gems are pushed as exact `.gem` files, the same as
+source and multi-ABI platform gems.
 
     $ curl --data-binary @gemcutter-0.2.1.gem \
            -H 'Authorization:rubygems_b9ce70c306b3a2e248679fbbbd66722d408d3c8c4f00566c' \
@@ -170,7 +179,8 @@ Submit a gem to RubyGems.org. Must post a built RubyGem in the request body.
 
 ### DELETE - `/api/v1/gems/yank`
 
-Remove a gem from RubyGems.org's index. Platform is optional.
+Remove a gem from RubyGems.org's index. Platform is optional. To yank one
+content-addressable variant, pass `ruby_abi` together with `platform`.
 
     $ curl -X DELETE -H 'Authorization:rubygems_b9ce70c306b3a2e248679fbbbd66722d408d3c8c4f00566c' \
            -d 'gem_name=bills' -d 'version=0.0.1' \
@@ -178,6 +188,13 @@ Remove a gem from RubyGems.org's index. Platform is optional.
            https://rubygems.org/api/v1/gems/yank
 
     Successfully deleted gem: bills (0.0.1)
+
+    $ curl -X DELETE -H 'Authorization:rubygems_b9ce70c306b3a2e248679fbbbd66722d408d3c8c4f00566c' \
+           -d 'gem_name=mygem' -d 'version=1.0.0' \
+           -d 'platform=x86_64-linux' -d 'ruby_abi=3.4' \
+           https://rubygems.org/api/v1/gems/yank
+
+    Successfully deleted gem: mygem (1.0.0)
 
 
 ### GET - `/api/v1/gems/[GEM NAME]/reverse_dependencies.json`
@@ -222,6 +239,7 @@ Returns an array of gem version details like the below:
         "platform": "ruby",
         "rubygems_version": ">= 0",
         "ruby_version": null,
+        "ruby_abi": null,
         "prerelease": false,
         "licenses": null,
         "requirements": null,
@@ -229,6 +247,11 @@ Returns an array of gem version details like the below:
         "spec_sha": "57b863cff56029a0085eaf1b3416b701ed4fa75418d062358b45753e270c9ffa"
       }
     ]
+
+For content-addressable native gems, version responses may include `ruby_abi`
+and `gem_uri` values that use the content-addressable filename. Use `platform`
+plus `ruby_abi` to identify the variant. The filename suffix is the content
+address.
 
 ### GET - `/api/v1/versions/[GEM NAME]/latest.json`
 
@@ -244,7 +267,7 @@ Returns an object containing the latest version of particular gem.
 
 Returns a dictionary with versions details for a specific gem version.
 
-To return the version for a specific platform (e.g. "ruby", "java", "x86_64-linux"), use the `platform` query parameter.
+To return the version for a specific platform (e.g. "ruby", "java", "x86_64-linux"), use the `platform` query parameter. For a content-addressable variant, pass `ruby_abi` together with `platform`.
 
     $ curl https://rubygems.org/api/v2/rubygems/coulda/versions/0.7.1.json
 
@@ -255,6 +278,7 @@ To return the version for a specific platform (e.g. "ruby", "java", "x86_64-linu
       "version_created_at": "2011-08-08T21:23:40.254Z",
       "version_downloads": 9676,
       "platform": "ruby",
+      "ruby_abi": null,
       "authors": "Evan David Light",
       "info": "Behaviour Driven Development derived from Cucumber but as an internal DSL with methods for reuse",
       "licenses": null,
@@ -291,18 +315,27 @@ To return the version for a specific platform (e.g. "ruby", "java", "x86_64-linu
       "summary": "Test::Unit-based acceptance testing DSL",
       "rubygems_version": ">= 0",
       "ruby_version": null,
+      "ruby_abi": null,
       "prerelease": false,
       "requirements": null
     }
 
+A content-addressable variant can be selected with both `platform` and
+`ruby_abi`:
+
+    $ curl 'https://rubygems.org/api/v2/rubygems/mygem/versions/1.0.0.json?platform=x86_64-linux&ruby_abi=3.4'
+
 ### GET - `/api/v2/rubygems/[GEM NAME]/versions/[VERSION NUMBER]/contents.(json|yaml|sha256)` (API v2)
 
 Returns the checksum of every file packaged in a specific gem version. The
-`platform` query parameter selects a non-default platform, as above.
+`platform` query parameter selects a non-default platform, as above. For a
+content-addressable variant, pass `ruby_abi` together with `platform`.
 
 Only versions pushed after RubyGems.org started recording file manifests have
 this data. Older versions respond `404` with "Content is unavailable for this
 version."
+
+    $ curl 'https://rubygems.org/api/v2/rubygems/mygem/versions/1.0.0/contents.json?platform=x86_64-linux&ruby_abi=3.4'
 
     $ curl https://rubygems.org/api/v2/rubygems/rails/versions/8.1.3.1/contents.json
 
@@ -665,6 +698,11 @@ SHA2-hashed concatenation of the gem name, the gem version and your API key.
            https://rubygems.org/api/v1/web_hooks/fire
 
     Successfully deployed webhook for all gems to http://example.com
+
+Push and yank webhook payloads may include `ruby_abi` for content-addressable
+native gems, and their gem URL may use the content-addressable filename. Consumers
+should use the payload's `platform` and `ruby_abi` fields instead of inferring
+platform from the filename.
 
 Activity Methods
 ------------

--- a/rubygems-org-compact-index-api.md
+++ b/rubygems-org-compact-index-api.md
@@ -138,13 +138,46 @@ Each following line gives information about 1 version of a rubygem with the form
 The pieces of each line are:
 
 1. **`VERSION`** - The version of the rubygem. Read VERSION until either `-` (minus) or space character is encountered.
-2. **`[-PLATFORM]`** - The platform, if it is not the default platform `ruby`. The first `-` (minus) character in the `VERSION[-PLATFORM]` chunk splits the VERSION and PLATFORM. The PLATFORM may contain more dashes. Read platform until a space is encountered.
+2. **`[-PLATFORM]`** - For multi-ABI platform gems, the suffix after the version is the platform, such as `x86_64-linux`. The first `-` (minus) character after VERSION separates VERSION from PLATFORM. Read the platform until a space is encountered. When the suffix is a content address, such as `78be552b`, the platform cannot be determined from that hash and is provided separately by the `platform` requirement.
 3. **`(SPACE)`** - The space character.
 4. **`[DEPENDENCY]`** - (optional) A dependency is another rubygem required by this gem. DEPENDENCY may contain spaces. See below for format.
 5. **`[(COMMA)DEPENDENCY]`** - (optional) A `,` (comma) character, indicating that another DEPENDENCY will follow. Read comma delimited DEPENCENCY chunks until the `|` (pipe) character is encountered.
 6. **`(PIPE)`** - The `|` (pipe) character.
 7. **`REQUIREMENT`** - Additional requirements for the rubygem, which always includes at least the SHA256 checksum. REQUIREMENT may contain spaces. See below for format.
 8. **`[(COMMA)REQUIREMENT]`** - (optional) A `,` (comma) character, indicating that another REQUIREMENT will follow. Read comma delimited REQUIREMENT chunks until the end of the line.
+
+#### Content-addressable native gems
+
+A content-addressable native gem has a filename that includes a shortened
+SHA-256 checksum calculated from the `.gem` file contents. Native gems may be
+published this way, with one gem file per platform and Ruby ABI. The filename
+and compact-index version token use a lowercase hex SHA-256 prefix instead of
+the platform:
+
+    mygem-1.0.0-78be552b.gem
+
+The content address is 8 to 64 characters. The platform and Ruby ABI are
+stored in metadata and compact-index requirements, not inferred from the
+filename suffix.
+
+Multi-ABI platform gem rows are unchanged:
+
+    1.0.0-x86_64-linux |checksum:<sha256>,ruby:>= 3.2.0
+
+A content-addressable gem row uses the content address in the version token and
+carries the real platform separately:
+
+    1.0.0-78be552b |checksum:<sha256>,ruby:~> 3.4.0,rubygems:>= 4.1.0.beta1,platform:x86_64-linux
+
+Important details:
+
+* Source gem rows and multi-ABI platform gem rows are unchanged.
+* The `platform` requirement is the real platform for content-addressable gems.
+* The `ruby` requirement represents the Ruby ABI compatibility, a single minor
+  ABI such as `~> 3.4.0`.
+* Content-addressable rows include a RubyGems version floor so old clients
+  ignore them and fall back to multi-ABI platform or source gems.
+* Legacy Marshal indexes exclude content-addressable variants.
 
 **`DEPENCENCY` Format**
 
@@ -169,9 +202,9 @@ Format:
 **`REQUIREMENT` Format**
 
 The REQUIREMENT chunk will always contain the `checksum` key. The `ruby` and `rubygems` keys are like a CONSTRAINT above, indicating a required ruby or rubygems version.
-The `created_at` key was added in version 2 of the format, described in the Format Versions section below.
+The `created_at` key was added in version 2 of the format, described in the Format Versions section below. The `platform` key carries the real platform for content-addressable gems when the version token contains a content address.
 
-The `checksum` is the SHA256 checksum of the `GEM-VERSION-PLATFORM.gem` file originally uploaded to rubygems.org. The SHA256 computed from the matching downloaded `.gem` file must match this checksum or the `.gem` must be considered corrupted.
+The `checksum` is the SHA256 checksum of the `.gem` file originally uploaded to RubyGems.org. For multi-ABI platform gems, that file is usually named `GEM-VERSION-PLATFORM.gem`. For content-addressable gems, it is named with the content address, such as `GEM-VERSION-78be552b.gem`. The SHA256 computed from the matching downloaded `.gem` file must match this checksum or the `.gem` must be considered corrupted.
 
 Examples:
 


### PR DESCRIPTION
## What

Documents content-addressable (skinny) native gem behavior across RubyGems Guides.

- Adds command-reference coverage for build, push, yank, install, fetch, list/search/info, update/outdated/dependency
- Documents compact index representation for skinny gems
- Documents RubyGems.org API `ruby_abi`/variant behavior
- Adds Bundler install/cache and lockfile notes

## Context

Client-side implementation: ruby/rubygems#9773
